### PR TITLE
Add `noInteraction` attribute to `HTMLComponent`, skip `noInteraction` elements in `inquirer_cli`

### DIFF
--- a/AU2/frontends/inquirer_cli.py
+++ b/AU2/frontends/inquirer_cli.py
@@ -104,7 +104,7 @@ def render(html_component, dependency_context={}):
                     new_dependency.update(out)
                 elif iteration > 0:
                     h = html_component.htmlComponents[iteration]
-                    if isinstance(h, Label) and last_step == -1:
+                    if h.noInteraction and last_step == -1:
                         iteration -= 1
                         continue
                     value = render(h, new_dependency)
@@ -574,7 +574,7 @@ def main():
             try:
                 if iteration == -1:
                     break
-                if last_step == -1 and isinstance(components[iteration], Label):
+                if last_step == -1 and components[iteration].noInteraction:
                     iteration -= 1
                     continue
                 result = render(components[iteration])

--- a/AU2/html_components/HTMLComponent.py
+++ b/AU2/html_components/HTMLComponent.py
@@ -10,6 +10,9 @@ class HTMLComponent:
 
     name = "abstract_HTMLComponent"
 
+    # whether a component requires user interaction (no: label, yes: textbox)
+    noInteraction = False
+
     def __init__(self):
         self.__decoders[self.name] = self.__class__
 

--- a/AU2/html_components/HiddenTextbox.py
+++ b/AU2/html_components/HiddenTextbox.py
@@ -5,6 +5,7 @@ from AU2.html_components import HTMLComponent
 
 class HiddenTextbox(HTMLComponent):
     name: str = "HiddenTextbox"
+    noInteraction: bool = True
 
     def __init__(self, identifier: str, default: str):
         self.identifier = identifier

--- a/AU2/html_components/Label.py
+++ b/AU2/html_components/Label.py
@@ -6,6 +6,7 @@ from AU2.html_components import HTMLComponent
 class Label(HTMLComponent):
 
     name = "Label"
+    noInteraction: bool = True
 
     def __init__(self, title: str):
         self.identifier = "Label" # needed for compatibility but not strictly relevant


### PR DESCRIPTION
Any use of `config` settings will [insert a `HiddenTextbox`](https://github.com/jsyiek/AU2/blob/master/AU2/plugins/CorePlugin.py#L434) at the start of the HTMLComponents that identifies the plugin. This is because config is handled through an export in the `CorePlugin` and not natively in the front-end.

These are passed over by the Inquirer front-end, which means we need to force it to skip it when going backward. The code wasn't doing this.

Resolves bug found in https://github.com/jsyiek/AU2/pull/26