### PR TITLE
Add functionality to suppress main menu exports

### DIFF
--- a/AU2/frontends/inquirer_cli.py
+++ b/AU2/frontends/inquirer_cli.py
@@ -31,7 +31,7 @@ from AU2.html_components.NamedSmallTextbox import NamedSmallTextbox
 from AU2.html_components.PathEntry import PathEntry
 from AU2.html_components.SelectorList import SelectorList
 from AU2.plugins.AbstractPlugin import Export
-from AU2.plugins.CorePlugin import PLUGINS
+from AU2.plugins.CorePlugin import PLUGINS, CorePlugin
 
 DATETIME_FORMAT = "%Y-%m-%d %H:%M"
 
@@ -501,36 +501,8 @@ def merge_dependency(component_list: List[HTMLComponent]) -> List[HTMLComponent]
 
 def main():
     while True:
-        exports = []
-        core_plugin = PLUGINS["CorePlugin"]
-        for p in PLUGINS:
-            exports += p.exports
-
-        for p in PLUGINS:
-            for hooked_export in p.hooked_exports:
-
-                # hideous disgusting lambda scoping rules means we have to do awful
-                # terrible no good very bad shenanigans to get the lambdas to correctly
-                # bind the values. ew!
-                exports.append(
-                    Export(
-                        "core_plugin_hook_" + hooked_export.identifier,
-                        hooked_export.display_name,
-                        lambda export_identifier=hooked_export.identifier: core_plugin.ask_custom_hook(export_identifier),
-                        lambda htmlResponse,
-                               identifier=p.identifier,
-                               export_identifier=hooked_export.identifier,
-                               producer_function=hooked_export.producer,
-                               call_first=hooked_export.call_first:
-                            core_plugin.answer_custom_hook(
-                                export_identifier,
-                                htmlResponse,
-                                data=producer_function(htmlResponse),
-                                call_first=call_first,
-                                hook_owner=identifier
-                            )
-                    )
-                )
+        core_plugin: CorePlugin = PLUGINS["CorePlugin"]
+        exports = core_plugin.get_all_exports()
 
         q = [inquirer.List(name="mode", message="Select mode",
                            choices=["Exit"] + sorted([e.display_name for e in exports]))]

--- a/AU2/plugins/custom_plugins/TargetingPlugin.py
+++ b/AU2/plugins/custom_plugins/TargetingPlugin.py
@@ -49,7 +49,7 @@ class TargetingPlugin(AbstractPlugin):
         super().__init__("TargetingPlugin")
         self.exports = [
             Export(
-                "TargetingPlugin",
+                "targeting_print_targeting_graph",
                 "Targeting Graph -> Print",
                 lambda *args: [],
                 self.answer_show_targeting_graph
@@ -58,13 +58,13 @@ class TargetingPlugin(AbstractPlugin):
 
         self.config_exports = [
             ConfigExport(
-                "TargetingPlugin_set_player_seeds",
+                "targeting_set_player_seeds",
                 "Targeting Graph -> Set player seeds",
                 self.ask_set_seeds,
                 self.answer_set_seeds
             ),
             ConfigExport(
-                "TargetingPlugin_set_random_seed",
+                "targeting_set_random_seed",
                 "Targeting Graph -> Set random seed",
                 self.ask_set_random_seed,
                 self.answer_set_random_seed


### PR DESCRIPTION
**Feature**: Allows you to explicitly hide menu options from appearing through a selector menu in plugin config.

**Tech debt**: Move the logic for hooked exports from front-end into back-end. 

**Robustness**: Disabled plugins' exports are still included in the suppression if they were previously suppressed (so users can easily reset them)

**Testing**: Manual testing involving selecting menu items for suppression and checking they do not appear on main menu