### PR TITLE
 [57] Display datetimes in event selector of Event -> Update

### DIFF
--- a/AU2/database/model/Assassin.py
+++ b/AU2/database/model/Assassin.py
@@ -1,7 +1,7 @@
 import datetime as dt
 
 from dataclasses_json import dataclass_json, config
-from typing import List, Dict, Any, Optional, Iterator
+from typing import List, Dict, Any, Optional, Iterator, Union
 
 from AU2.database.GenericStateDatabase import GENERIC_STATE_DATABASE
 from AU2.database.model.PersistentFile import PersistentFile
@@ -82,7 +82,7 @@ class Assassin(PersistentFile):
 
         return self.pseudonyms[i]
 
-    def get_pseudonym_validity(self, i: int) -> dt.datetime | None:
+    def get_pseudonym_validity(self, i: int) -> Union[dt.datetime, None]:
         """
         Fetches the start of validity for a given pseudonym, referenced by index.
         The start of validity is notionally the point in time in the game when the assassin was granted the pseudonym,
@@ -98,7 +98,7 @@ class Assassin(PersistentFile):
         """
         return self.pseudonym_datetimes[i] if i in self.pseudonym_datetimes else None
 
-    def add_pseudonym(self, val: str, valid_from: dt.datetime | None = get_now_dt()) -> int:
+    def add_pseudonym(self, val: str, valid_from: Union[dt.datetime, None] = get_now_dt()) -> int:
         """
         Adds a new pseudonym to this assassin.
 
@@ -118,7 +118,7 @@ class Assassin(PersistentFile):
         self.pseudonyms.append(val)
         return new_i
 
-    def edit_pseudonym(self, i: int, new_val: str, new_valid_from: dt.datetime | None):
+    def edit_pseudonym(self, i: int, new_val: str, new_valid_from: Union[dt.datetime, None]):
         """
         Edits a pseudonym, referenced by index, from this assassin.
         Both the new text and new start of validity must be specified.

--- a/AU2/plugins/CorePlugin.py
+++ b/AU2/plugins/CorePlugin.py
@@ -1,7 +1,7 @@
 import glob
 import os.path
 
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
 from AU2.database.AssassinsDatabase import ASSASSINS_DATABASE
 from AU2.database.EventsDatabase import EVENTS_DATABASE
@@ -145,7 +145,7 @@ class CorePlugin(AbstractPlugin):
                 "Event -> Update",
                 self.ask_core_plugin_update_event,
                 self.answer_core_plugin_update_event,
-                (lambda: [v for v in EVENTS_DATABASE.events],)
+                (self.gather_events,)
             ),
             Export(
                 self.PLUGIN_ENABLE_EXPORT,
@@ -412,6 +412,13 @@ class CorePlugin(AbstractPlugin):
         for p in PLUGINS:
             components += p.on_event_update(event, html_response_args)
         return components
+
+    def gather_events(self) -> List[Tuple[str, str]]:
+        # headline is truncated because `inquirer` doesn't deal with overlong options well
+        return [
+                (f"[{event.datetime.strftime('%Y-%m-%d %H:%M %p')}] {event.headline[0:25].rstrip()}", identifier)
+                for identifier, event in sorted(EVENTS_DATABASE.events.items(), key=lambda x: x[1].datetime, reverse=True)
+        ]
 
     def ask_core_plugin_delete_event(self, event_id: str):
         event = EVENTS_DATABASE.get(event_id)

--- a/AU2/plugins/CorePlugin.py
+++ b/AU2/plugins/CorePlugin.py
@@ -138,7 +138,7 @@ class CorePlugin(AbstractPlugin):
                 "Event -> Delete",
                 self.ask_core_plugin_delete_event,
                 self.answer_core_plugin_delete_event,
-                (lambda: [v for v in EVENTS_DATABASE.events],)
+                (self.gather_events,)
             ),
             Export(
                 "core_event_update_event",


### PR DESCRIPTION
This is the "minimum change" for issue #57.

This PR doesn't change the plugin framework, but changes the `options_functions` of Event -> Update to instead return a list of tuples, where the first part of each tuple is what is displayed to the user and the second part is what will be passed to the plugin's `ask` function. The options are also sorted by event datetime, in reverse chronological order.

The display value of each event is the datetime + truncated headline. This means it no longer includes the internal identifier for the event; I'd be interested in hearing thoughts about this.