### PR TITLE
[44] Added Assassin -> Hide export

### DIFF
--- a/AU2/database/model/Assassin.py
+++ b/AU2/database/model/Assassin.py
@@ -24,6 +24,10 @@ class Assassin(PersistentFile):
     college: str
     notes: str
     is_police: bool
+    # we should not delete assassins because that will break any references to that assassin.
+    # most significantly, it would mess up the targeting graph.
+    # but it is useful to hide certain assassins in interfaces (e.g. an assassin who has been cloned into police)
+    hidden: bool = False
     # almost everything that is stateful is probably best placed in an event
     # but for a few plugins, it might make sense to place the information directly onto the assassin
     # make sure you know what you're doing (modifications here can't be undone with a later event state change)
@@ -161,7 +165,7 @@ class Assassin(PersistentFile):
         if i in self.pseudonym_datetimes:
             del self.pseudonym_datetimes[i]
 
-    def pseudonyms_until(self, ts: dt.datetime = get_now_dt()) -> Iterator[str]:
+    def pseudonyms_until(self, ts: Optional[dt.datetime] = None) -> Iterator[str]:
         """
         A generator yielding all the assassin's pseudonyms valid at a given datetime.
         Pseudonyms with no datetime set are considered always valid.
@@ -173,6 +177,9 @@ class Assassin(PersistentFile):
         Yields:
             the next pseudonym of the assassin that is valid before datetime `ts`.
         """
+        if not ts:
+            ts = get_now_dt()
+        
         for (i, p) in enumerate(self.pseudonyms):
             if p and self.pseudonym_datetimes.get(i, ts) <= ts:
                 yield p

--- a/AU2/frontends/inquirer_cli.py
+++ b/AU2/frontends/inquirer_cli.py
@@ -593,7 +593,7 @@ def render(html_component, dependency_context={}):
         q = [
             inquirer.List(
                 name="emails",
-                message="Which assassins would you like to email?",
+                message="Which assassins would you like to email? (All options exclude hidden assassins)",
                 choices=["UPDATES ONLY", "ALL", "ALL ALIVE", "ALL POLICE", "MANUAL SELECTION"],
                 default="UPDATES ONLY",
             )

--- a/AU2/plugins/custom_plugins/SRCFPlugin.py
+++ b/AU2/plugins/custom_plugins/SRCFPlugin.py
@@ -272,10 +272,11 @@ class SRCFPlugin(AbstractPlugin):
             for e in EVENTS_DATABASE.events.values():
                 death_manager.add_event(e)
 
-            alive_assassins = [a.identifier for a in ASSASSINS_DATABASE.assassins.values() if
-                               a.is_police or not death_manager.is_dead(a)]
-
-            police_assassins = [a.identifier for a in ASSASSINS_DATABASE.assassins.values() if a.is_police]
+            # note: hidden assassins will be excluded
+            alive_assassins = ASSASSINS_DATABASE.get_identifiers(include=(
+                lambda a: a.is_police or not death_manager.is_dead(a)
+            ))
+            police_assassins = ASSASSINS_DATABASE.get_identifiers(include=lambda a: a.is_police)
 
             return [
                 Checkbox(
@@ -297,6 +298,7 @@ class SRCFPlugin(AbstractPlugin):
                 ),
                 EmailSelector(
                     identifier=self.html_ids["email_require_send"],
+                    # note: hidden assassins will be excluded
                     assassins=ASSASSINS_DATABASE.get_identifiers(),
                     alive_assassins=alive_assassins,
                     police_assassins=police_assassins


### PR DESCRIPTION
This allows the umpire to toggle the visibility for each assassin.
An assassin is hidden by setting its `hidden` attribute to `True`.
Hidden assassins are not included in the options for `Assassin -> Update` or in the `AssassinPseudonymPair` component of `Event -> Create`.
Hidden assassins that are *already* in the event are included in the `AssassinPseudonymPair` component of `Event -> Update`, but the rest are not.
Hiding an assassin has no other effects currently. In particular, it has no effect on `TargetingPlugin` or sending emails with `SRCFPlugin`.