### PR TITLE
[60] Bounty plugin

### DIFF
--- a/AU2/plugins/CorePlugin.py
+++ b/AU2/plugins/CorePlugin.py
@@ -436,7 +436,7 @@ class CorePlugin(AbstractPlugin):
             SelectorList(
                 self.identifier + "_config",
                 title="Enable or disable plugins",
-                options=plugins,
+                options=sorted(plugins),
                 defaults=[p for p in plugins if GENERIC_STATE_DATABASE.plugin_map[p]]
             )
         ]

--- a/AU2/plugins/custom_plugins/BountyPlugin.py
+++ b/AU2/plugins/custom_plugins/BountyPlugin.py
@@ -1,0 +1,202 @@
+import os
+from dataclasses import dataclass
+from typing import Dict, Any, List
+
+from AU2 import ROOT_DIR
+from AU2.database.AssassinsDatabase import ASSASSINS_DATABASE
+from AU2.database.GenericStateDatabase import GENERIC_STATE_DATABASE
+from AU2.html_components import HTMLComponent
+from AU2.html_components.MetaComponents.Searchable import Searchable
+from AU2.html_components.SimpleComponents.Checkbox import Checkbox
+from AU2.html_components.SimpleComponents.DefaultNamedSmallTextbox import DefaultNamedSmallTextbox
+from AU2.html_components.SimpleComponents.HiddenTextbox import HiddenTextbox
+from AU2.html_components.SimpleComponents.InputWithDropDown import InputWithDropDown
+from AU2.html_components.SimpleComponents.Label import Label
+from AU2.plugins.AbstractPlugin import AbstractPlugin, Export
+from AU2.plugins.CorePlugin import registered_plugin
+from AU2.plugins.constants import WEBPAGE_WRITE_LOCATION
+from AU2.plugins.util.date_utils import get_now_dt
+
+TABLE_TEMPLATE = """
+<table xmlns="" class="playerlist">
+    <tr><th>TARGET</th><th>BOUNTY POSTER</th><th>ALLEGED TRANSGRESSION</th><th>REWARD</th></tr>
+    {ROWS}
+</table>
+"""
+
+ROW_TEMPLATE = """
+<tr><td>{TARGET_NAME}</td><td>{PLACER_NAME}</td><td>{CRIME}</td><td>{REWARD}</td></tr>
+"""
+
+BOUNTIES_PAGE_TEMPLATE: str
+with open(os.path.join(ROOT_DIR, "plugins", "custom_plugins", "html_templates", "bounties.html"), "r", encoding="utf-8",
+          errors="ignore") as F:
+    BOUNTIES_PAGE_TEMPLATE = F.read()
+
+
+@dataclass
+class Bounty:
+    identifier: str = ""
+    target_id: str = ""
+    placer_id: str = ""
+    crime: str = ""
+    reward: str = ""
+    active: bool = True
+
+    @staticmethod
+    def from_dict(identifier: str, d: Dict[str, Any]):
+        b = Bounty(
+            identifier,
+            d.get("target_id", ""),
+            d.get("placer_id", ""),
+            d.get("crime", "Nothing...?"),
+            d.get("reward", "Nothing...?"),
+            d.get("active", False)
+        )
+        b.make_identifier()
+        return b
+
+    def make_identifier(self):
+        self.identifier = self.identifier or f"({GENERIC_STATE_DATABASE.get_unique_str()}) {self.target_id[0:8]} from {self.placer_id[0:8]}"
+
+    def to_dict(self):
+        return {
+            "target_id": self.target_id,
+            "placer_id": self.placer_id,
+            "crime": self.crime,
+            "reward": self.reward,
+            "active": self.active
+        }
+
+
+@registered_plugin
+class BountyPlugin(AbstractPlugin):
+    def __init__(self):
+        super().__init__("BountyPlugin")
+
+        self.html_ids = {
+            "identifier": "identifier",
+            "target": "target_id",
+            "placer": "placer_id",
+            "crime": "crime",
+            "reward": "reward",
+            "active": "active"
+        }
+
+        self.exports = [
+            Export(
+                "bounty_add_bounty",
+                "Bounties -> Add bounty",
+                self.ask_create_bounty,
+                self.answer_set_bounty
+            ),
+            Export(
+                "bounty_update_bounty",
+                "Bounties -> Update bounty",
+                self.ask_update_bounty,
+                self.answer_set_bounty,
+                [self.get_bounty_ids]
+            )
+        ]
+
+    def ask_create_bounty(self):
+        return self._bounty_questions()
+
+    def ask_update_bounty(self, bounty_id: str):
+        return self._bounty_questions(self._read_bounty(bounty_id))
+
+    def answer_set_bounty(self, html_response):
+        bounties_dict = GENERIC_STATE_DATABASE.arb_state.setdefault(self.identifier, {}).setdefault("bounties", {})
+        bounty = Bounty.from_dict(html_response[self.html_ids["identifier"]], html_response)
+        bounties_dict[bounty.identifier] = bounty.to_dict()
+        return [Label("[BOUNTY] Success!")]
+
+    def _bounty_questions(self, default=Bounty()):
+
+        def setter(component, options):
+            component.options = options
+            if component.selected and component.selected not in options:
+                component.options.append(component.selected)
+
+        return [
+            HiddenTextbox(
+                identifier=self.html_ids["identifier"],
+                default=default.identifier
+            ),
+            Searchable(
+                InputWithDropDown(
+                    identifier=self.html_ids["target"],
+                    title="Who is the bounty on?",
+                    options=ASSASSINS_DATABASE.get_identifiers(),
+                    selected=default.target_id
+                ),
+                title="Who is the bounty on? (Search)",
+                accessor=lambda i: i.options,
+                setter=setter
+            ),
+            Searchable(
+                InputWithDropDown(
+                    identifier=self.html_ids["placer"],
+                    title="Who is the bounty on?",
+                    options=ASSASSINS_DATABASE.get_identifiers(),
+                    selected=default.placer_id
+                ),
+                title="Who is placing the bounty? (Search)",
+                accessor=lambda i: i.options,
+                setter=setter
+            ),
+            DefaultNamedSmallTextbox(
+                identifier=self.html_ids["crime"],
+                title="What is the crime?",
+                default=default.crime
+            ),
+            DefaultNamedSmallTextbox(
+                identifier=self.html_ids["reward"],
+                title="What is the reward?",
+                default=default.reward
+            ),
+            Checkbox(
+                identifier=self.html_ids["active"],
+                title="Should the bounty be posted on the website?",
+                checked=True
+            )
+        ]
+
+    def on_page_generate(self, _) -> List[HTMLComponent]:
+        bounties_dict = GENERIC_STATE_DATABASE.arb_state.setdefault(self.identifier, {}).setdefault("bounties", {})
+        bounties = [Bounty.from_dict(identifier, bounties_dict[identifier]) for identifier in bounties_dict]
+        bounties = [b for b in bounties if b.active]
+
+        table_str = "<p>Ah, no bounties yet.</p>"
+
+        if bounties:
+            rows = []
+            for b in bounties:
+                rows.append(
+                    ROW_TEMPLATE.format(
+                        TARGET_NAME=ASSASSINS_DATABASE.assassins[b.target_id].real_name,
+                        PLACER_NAME=ASSASSINS_DATABASE.assassins[b.placer_id].real_name,
+                        CRIME=b.crime,
+                        REWARD=b.reward
+                    )
+                )
+            table_str = TABLE_TEMPLATE.format(ROWS="\n".join(rows))
+
+        with open(os.path.join(WEBPAGE_WRITE_LOCATION, "bounties.html"), "w+", encoding="utf-8") as F:
+            F.write(
+                BOUNTIES_PAGE_TEMPLATE.format(
+                    YEAR=get_now_dt().year,
+                    TABLE_OPTIONAL=table_str
+                )
+            )
+        return [Label("[BOUNTY] Success!")]
+
+    def _read_bounty(self, bounty_id: str):
+        return Bounty.from_dict(
+            bounty_id,
+            GENERIC_STATE_DATABASE.arb_state.setdefault(self.identifier, {}).setdefault("bounties", {}).setdefault(
+                bounty_id, {})
+        )
+
+    def get_bounty_ids(self):
+        return list(GENERIC_STATE_DATABASE.arb_state.setdefault(self.identifier, {}).setdefault("bounties", {}).keys())

--- a/AU2/plugins/custom_plugins/TargetingPlugin.py
+++ b/AU2/plugins/custom_plugins/TargetingPlugin.py
@@ -370,8 +370,6 @@ class TargetingPlugin(AbstractPlugin):
 
         deaths = deaths_adj
 
-        response.append(Label("UPDATING"))
-
         # collect a list of [non-unique] players who need new targets
         targeters = sum((targeters_graph[d] for d in deaths), start=[])
         targeters = [t for t in targeters if t not in deaths]

--- a/AU2/plugins/custom_plugins/html_templates/bounties.html
+++ b/AU2/plugins/custom_plugins/html_templates/bounties.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<link rel="preconnect" href="https://fonts.googleapis.com">
+	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+	<link href="https://fonts.googleapis.com/css2?family=Aref+Ruqaa+Ink:wght@700&family=Roboto+Slab&display=swap" rel="stylesheet">
+	<link rel="stylesheet" type="text/css" href="newassassins.css">
+ 	<link rel="shortcut icon" href="img/cloak3.png">
+	<script src="main.js"></script>
+ 	<title>The Assassins' Guild</title>
+</head>
+<body>
+<div class="backgroundimg">
+<div class="wrapper">
+
+	<div w3-include-html="header.html"></div>
+
+	<!--Main Content-->   <h2>Wanted List</h2>
+
+
+<p xmlns="">
+    This is the <b>List of Bountied players</b>. Being on this list does not make a player a licit target where they might otherwise not. If you're a regular assassin and do not have them as a target, and this player is not Wanted or Incompetent, you will go Wanted for killing them! But maybe the bounty is worth it...?
+</p>
+
+{TABLE_OPTIONAL}
+
+
+<!--Footer-->
+	<div class="footer">
+		<h5>Assassins' Guild {YEAR}</h5>
+	</div>
+</div>
+</div>
+
+<script>
+	includeHTML();
+</script>
+</body></html>


### PR DESCRIPTION
Closes #60 

**Problem**: A player may end up placing a bounty on another player within the next day or so. This one slipped through the cracks of AU2 development as it was previously incorporated into the `MafiaPlugin` (which is now seriously out-of-date) and so didn't get an issue created back during the first AU2 development rush (meaning it wasn't taken in the second).

**Solution**: A simple bounty plugin. After discussion with the umpires, we're OK with the target's and bounty placer's names being public information. These do not use events unlike wantedness/etc. as there is no time expiry that makes sense to associate with a bounty. It's also a very rare occurrence and I'm not keen to put more questions on the umpire's to-do list whenever they add the event ("make the common case fast" and all that). Happy to hear thoughts on this. 

**Testing**: Manual. We really need to start using the testing framework. It's criminally underused.