### PR TITLE
[63] Assassin -> Resurrect as Police

### DIFF
--- a/AU2/database/AssassinsDatabase.py
+++ b/AU2/database/AssassinsDatabase.py
@@ -72,7 +72,8 @@ class AssassinsDatabase(PersistentFile):
         Returns:
             list of identifiers sorted alphabetically, filtered according to the `include` and `include_hidden` functions
         """
-        return sorted([a.identifier for a in self.get_filtered(include=include, include_hidden=include_hidden)])
+        return sorted([a.identifier for a in self.get_filtered(include=include, include_hidden=include_hidden)],
+                      key=lambda x: x.lower())
 
     def get_ident_pseudonym_pairs(self, *,
                      include: Callable[[Assassin], bool] = lambda x: True,

--- a/AU2/database/model/Assassin.py
+++ b/AU2/database/model/Assassin.py
@@ -5,7 +5,7 @@ from typing import List, Dict, Any, Optional, Iterator, Union
 
 from AU2.database.GenericStateDatabase import GENERIC_STATE_DATABASE
 from AU2.database.model.PersistentFile import PersistentFile
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 
 from AU2 import TIMEZONE
 from AU2.plugins.util.date_utils import get_now_dt
@@ -61,6 +61,24 @@ class Assassin(PersistentFile):
         if not self.identifier:
             dotdotdot = "..." if len(self.pseudonyms[0]) > 15 else ""
             self.identifier = f"{self.real_name} ({self.pseudonyms[0][:15]}{dotdotdot}) ID: {self._secret_id}"
+
+    def clone(self, **changes):
+        """
+        Creates a clone of this assassin with a new identifier and specified changes.
+        This is used for resurrecting an assassin as police.
+
+        Args:
+            **changes: use keyword arguments to specify attributes of clone where they should differ from the original.
+                Setting a new identifier or _secret_id has no effect; the cloned assassin will still have these set
+                automatically.
+
+        Returns:
+            A clone of this Assassin, with a different identifier and _secret_id
+        """
+        # allow __post_init__ to generate the new identifier and _secret_id
+        changes["identifier"] = ""
+        changes["_secret_id"] = ""
+        return replace(self, **changes)
 
     def get_pseudonym(self, i: int) -> str:
         """

--- a/AU2/database/model/Assassin.py
+++ b/AU2/database/model/Assassin.py
@@ -42,7 +42,7 @@ class Assassin(PersistentFile):
     pseudonym_datetimes: Dict[int, dt.datetime] = field(
         default_factory=dict,
         metadata=config(
-            encoder=lambda d: {k: ts.timestamp() for k,ts in d.items()},
+            encoder=lambda d: {k: ts.timestamp() for k, ts in d.items()},
             decoder=lambda d: {int(k): dt.datetime.fromtimestamp(ts).astimezone().astimezone(TIMEZONE) for k,ts in d.items()}
         )
     )

--- a/AU2/database/model/Assassin.py
+++ b/AU2/database/model/Assassin.py
@@ -195,7 +195,7 @@ class Assassin(PersistentFile):
         Yields:
             the next pseudonym of the assassin that is valid before datetime `ts`.
         """
-        if not ts:
+        if ts is None:
             ts = get_now_dt()
         
         for (i, p) in enumerate(self.pseudonyms):

--- a/AU2/plugins/CorePlugin.py
+++ b/AU2/plugins/CorePlugin.py
@@ -117,13 +117,6 @@ class CorePlugin(AbstractPlugin):
                 ((lambda: ASSASSINS_DATABASE.get_identifiers()),)
             ),
             Export(
-                "core_assassin_to_police",
-                "Assassin -> Resurrect as Police",
-                self.ask_core_plugin_assassin_to_police,
-                self.answer_core_plugin_assassin_to_police,
-                (self.gather_dead_non_police,)
-            ),
-            Export(
                 "core_event_create_event",
                 "Event -> Create",
                 self.ask_core_plugin_create_event,
@@ -407,29 +400,6 @@ class CorePlugin(AbstractPlugin):
         for p in PLUGINS:
             return_components += p.on_assassin_update(assassin, html_response_args)
         return return_components
-
-    def gather_dead_non_police(self) -> List[str]:
-        # use targeting plugin as proxy for whether we have perma-death
-        targeting_enabled = any(p.identifier == "TargetingPlugin" for p in PLUGINS)
-        death_manager = DeathManager(perma_death=targeting_enabled)
-        for e in EVENTS_DATABASE.events.values():
-            death_manager.add_event(e)
-        return ASSASSINS_DATABASE.get_identifiers(include=(lambda a: death_manager.is_dead(a) and not a.is_police))
-
-    def ask_core_plugin_assassin_to_police(self, ident: str):
-        components = [HiddenTextbox(identifier=self.HTML_SECRET_ID, default=ident),
-                      NamedSmallTextbox(identifier=self.html_ids["Pseudonym"], title="New initial pseudonym")]
-        return components
-
-    def answer_core_plugin_assassin_to_police(self, html_response_args: Dict):
-        ident = html_response_args[self.HTML_SECRET_ID]
-        assassin = ASSASSINS_DATABASE.get(ident)
-        new_pseudonym = html_response_args[self.html_ids["Pseudonym"]]
-        new_assassin = assassin.clone(hidden=False, is_police=True, pseudonyms=[new_pseudonym])
-        ASSASSINS_DATABASE.add(new_assassin)
-        # hide the old assassin
-        assassin.hidden = True
-        return [Label(f"[CORE] Resurrected {ident} as {new_assassin.identifier}.")]
 
     def ask_core_plugin_create_event(self):
         components = []

--- a/AU2/plugins/CorePlugin.py
+++ b/AU2/plugins/CorePlugin.py
@@ -213,6 +213,7 @@ class CorePlugin(AbstractPlugin):
     def on_assassin_request_update(self, assassin: Assassin):
         html = [
             HiddenTextbox(self.HTML_SECRET_ID, assassin.identifier),
+            Label("Assassin type: " + ("Police" if assassin.is_police else "Full Player")),
             EditablePseudonymList(
                 self.html_ids["Pseudonym"], "Edit Pseudonyms",
                 (PseudonymData(p, assassin.get_pseudonym_validity(i)) for i, p in enumerate(assassin.pseudonyms))

--- a/AU2/plugins/CorePlugin.py
+++ b/AU2/plugins/CorePlugin.py
@@ -377,6 +377,8 @@ class CorePlugin(AbstractPlugin):
 
     def ask_core_plugin_create_assassin(self):
         components = []
+        for p in PLUGINS:
+            components += p.on_assassin_request_create()
         return components
 
     def answer_core_plugin_create_assassin(self, html_response_args: Dict):
@@ -407,7 +409,9 @@ class CorePlugin(AbstractPlugin):
         return return_components
 
     def gather_dead_non_police(self) -> List[str]:
-        death_manager = DeathManager(perma_death=True)
+        # use targeting plugin as proxy for whether we have perma-death
+        targeting_enabled = any(p.identifier == "TargetingPlugin" for p in PLUGINS)
+        death_manager = DeathManager(perma_death=targeting_enabled)
         for e in EVENTS_DATABASE.events.values():
             death_manager.add_event(e)
         return ASSASSINS_DATABASE.get_identifiers(include=(lambda a: death_manager.is_dead(a) and not a.is_police))

--- a/AU2/plugins/custom_plugins/PolicePlugin.py
+++ b/AU2/plugins/custom_plugins/PolicePlugin.py
@@ -90,8 +90,8 @@ class PolicePlugin(AbstractPlugin):
             Export(
                 "police_plugin_assassin_to_police",
                 "Assassin -> Resurrect as Police",
-                self.ask_core_plugin_assassin_to_police,
-                self.answer_core_plugin_assassin_to_police,
+                self.ask_resurrect_as_police,
+                self.answer_resurrect_as_police,
                 (self.gather_dead_non_police,)
             ),
         ]
@@ -135,16 +135,18 @@ class PolicePlugin(AbstractPlugin):
             death_manager.add_event(e)
         return ASSASSINS_DATABASE.get_identifiers(include=(lambda a: death_manager.is_dead(a) and not a.is_police))
 
-    def ask_core_plugin_assassin_to_police(self, ident: str):
+    def ask_resurrect_as_police(self, ident: str):
         components = [HiddenTextbox(identifier=self.html_ids["Assassin"], default=ident),
                       NamedSmallTextbox(identifier=self.html_ids["Pseudonym"], title="New initial pseudonym")]
         return components
 
-    def answer_core_plugin_assassin_to_police(self, html_response_args: Dict):
+    # TODO: make resurrection a hook, so that plugins can decide what to do with plugin data stored in assassins
+    #       current behaviour is to copy it over.
+    def answer_resurrect_as_police(self, html_response_args: Dict):
         ident = html_response_args[self.html_ids["Assassin"]]
         assassin = ASSASSINS_DATABASE.get(ident)
         new_pseudonym = html_response_args[self.html_ids["Pseudonym"]]
-        new_assassin = assassin.clone(hidden=False, is_police=True, pseudonyms=[new_pseudonym])
+        new_assassin = assassin.clone(hidden=False, is_police=True, pseudonyms=[new_pseudonym], pseudonym_datetimes={})
         ASSASSINS_DATABASE.add(new_assassin)
         # hide the old assassin
         assassin.hidden = True

--- a/AU2/test/plugins/util/custom_plugins/test_PolicePlugin.py
+++ b/AU2/test/plugins/util/custom_plugins/test_PolicePlugin.py
@@ -1,0 +1,73 @@
+import datetime
+
+from AU2.database.AssassinsDatabase import ASSASSINS_DATABASE
+from AU2.database.EventsDatabase import EVENTS_DATABASE
+from AU2.database.model import Event
+from AU2.plugins.custom_plugins.PolicePlugin import PolicePlugin
+from AU2.test.test_utils import MockGame, some_players, plugin_test, dummy_event
+
+
+class TestPolicePlugin:
+
+    @plugin_test
+    def test_resurrect_as_police(self):
+        """
+        Tests that Assassin -> Resurrect as Police
+        """
+        k = 50
+        n = 4*k
+        p = some_players(n)
+        game = MockGame().having_assassins(p)
+        plugin = PolicePlugin()
+
+        # add some regular deaths
+        for i in range(k):
+            game.assassin(p[i]).kills(p[i + k])
+        # add some police deaths
+        for i in range(2*k, 3*k):
+            game.assassin(p[i + k]).is_police()
+            game.assassin(p[i]).kills(p[i + k])
+
+        # hide some assassins
+        game.assassin(p[k-1]).with_accomplices(p[2*k-1], p[3*k-1], p[4*k-1]).are_hidden()
+
+        # check that the list of players that can be resurrected is correct
+        # (only the dead non-police, non-hidden assassins should be shown!)
+        assert set(plugin.gather_dead_non_police()) == {p[i] + " identifier" for i in range(k, 2*k-1)}
+
+        # check that players get resurrected correctly
+        ##############################################
+        new_pseudonym = "New Pseudonym"
+        old_assassin = ASSASSINS_DATABASE.get(p[k] + " identifier")
+        old_idents = set(ASSASSINS_DATABASE.get_identifiers(include_hidden=lambda _: True))
+        # the way identifiers are generated in test mode messes with cloning
+        # this is kind of hacky but at least lets us verify that Assassin.__post_init__ gets called
+        old_assassin.real_name = old_assassin.real_name + " The Great"
+        to_copy = {
+            "real_name" : old_assassin.real_name,
+            "email" : old_assassin.email,
+            "college" : old_assassin.college,
+            "address" : old_assassin.address,
+            "water_status": old_assassin.water_status,
+            "notes": old_assassin.notes,
+            "pronouns": old_assassin.pronouns
+        }
+        plugin.answer_resurrect_as_police({plugin.html_ids["Assassin"]: p[k] + " identifier",
+                                        plugin.html_ids["Pseudonym"]: new_pseudonym})
+        # implicitly this verifies that the clone has a unique identifier
+        new_assassins = ASSASSINS_DATABASE.get_filtered(include=lambda a: a.identifier not in old_idents)
+        assert len(new_assassins) == 1
+        new_assassin = new_assassins[0]
+        # check database integrity
+        assert ASSASSINS_DATABASE.get(new_assassin.identifier) == new_assassin
+        assert ASSASSINS_DATABASE.get(p[k] + " identifier") != new_assassin
+        # check new assassin has correct attributes
+        assert not new_assassin.hidden
+        assert new_assassin.is_police
+        for key, val in to_copy.items():
+            assert getattr(new_assassin, key) == val
+        assert new_assassin.pseudonyms == [new_pseudonym]
+        assert new_assassin.pseudonym_datetimes == {}
+        # check the list of resurrectable assassins is correct after resurrection
+        assert old_assassin.hidden
+        assert set(plugin.gather_dead_non_police()) == {p[i] + " identifier" for i in range(k+1, 2 * k - 1)}

--- a/AU2/test/test_utils.py
+++ b/AU2/test/test_utils.py
@@ -182,6 +182,21 @@ class ProxyAssassin:
         """
         return self.are_police()
 
+    def are_hidden(self) -> MockGame:
+        """
+        Makes these assassins hidden
+        """
+        for a in self.assassins:
+            ASSASSINS_DATABASE.assassins[self.__ident(a)].hidden = True
+
+        return self.mockGame
+
+    def is_hidden(self):
+        """
+        Makes this assassin hidden
+        """
+        return self.are_hidden()
+
     def with_accomplices(self, *others: str) -> "ProxyAssassin":
         """
         Adds several accomplices to the proxy assassin


### PR DESCRIPTION
This builds on PR #59 to address issue #63.

It adds a new `Assassin -> Resurrect as Police` export to ~~`CorePlugin`~~ (EDIT: moved to `PolicePlugin`). The user selects from all *dead, non-police, non-hidden* assassins, and is prompted to give a new initial pseudonym for the selected assassin. The assassin is then cloned (with a new identifier), with the clone set to be police and have the entered pseudonym as its sole pseudonym.