### PR TITLE
[13] Open season and Scoring plugin

### DIFF
--- a/AU2/database/model/Assassin.py
+++ b/AU2/database/model/Assassin.py
@@ -8,7 +8,7 @@ from AU2.database.model.PersistentFile import PersistentFile
 from dataclasses import dataclass, field, replace
 
 from AU2 import TIMEZONE
-from AU2.plugins.util.date_utils import get_now_dt
+from AU2.plugins.util.date_utils import get_now_dt, dt_to_timestamp, timestamp_to_dt
 
 
 @dataclass_json
@@ -42,8 +42,8 @@ class Assassin(PersistentFile):
     pseudonym_datetimes: Dict[int, dt.datetime] = field(
         default_factory=dict,
         metadata=config(
-            encoder=lambda d: {k: ts.timestamp() for k, ts in d.items()},
-            decoder=lambda d: {int(k): dt.datetime.fromtimestamp(ts).astimezone().astimezone(TIMEZONE) for k,ts in d.items()}
+            encoder=lambda d: {k: dt_to_timestamp(ts) for k, ts in d.items()},
+            decoder=lambda d: {int(k): timestamp_to_dt(ts) for k, ts in d.items()}
         )
     )
 

--- a/AU2/database/model/Event.py
+++ b/AU2/database/model/Event.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, Tuple, List
 from AU2 import TIMEZONE
 from AU2.database.GenericStateDatabase import GENERIC_STATE_DATABASE
 from AU2.database.model import PersistentFile
+from AU2.plugins.util.date_utils import dt_to_timestamp, timestamp_to_dt
 
 
 @dataclass_json
@@ -22,8 +23,8 @@ class Event(PersistentFile):
     # time the event occurred
     datetime: dt.datetime = field(
         metadata=config(
-            encoder=dt.datetime.timestamp,
-            decoder=lambda ts: dt.datetime.fromtimestamp(ts).astimezone().astimezone(TIMEZONE)
+            encoder=dt_to_timestamp,
+            decoder=timestamp_to_dt
         )
     )
 

--- a/AU2/frontends/inquirer_cli.py
+++ b/AU2/frontends/inquirer_cli.py
@@ -21,6 +21,7 @@ from AU2.html_components.DependentComponents.AssassinDependentTextEntry import A
 from AU2.html_components.DependentComponents.AssassinPseudonymPair import AssassinPseudonymPair
 from AU2.html_components.SimpleComponents.Checkbox import Checkbox
 from AU2.html_components.SimpleComponents.DatetimeEntry import DatetimeEntry
+from AU2.html_components.SimpleComponents.OptionalDatetimeEntry import OptionalDatetimeEntry
 from AU2.html_components.SimpleComponents.DefaultNamedSmallTextbox import DefaultNamedSmallTextbox
 from AU2.html_components.MetaComponents.Dependency import Dependency
 from AU2.html_components.SimpleComponents.EmailSelector import EmailSelector
@@ -28,6 +29,7 @@ from AU2.html_components.SimpleComponents.HiddenTextbox import HiddenTextbox
 from AU2.html_components.SimpleComponents.InputWithDropDown import InputWithDropDown
 from AU2.html_components.DependentComponents.AssassinDependentKillEntry import AssassinDependentKillEntry
 from AU2.html_components.SimpleComponents.IntegerEntry import IntegerEntry
+from AU2.html_components.SimpleComponents.FloatEntry import FloatEntry
 from AU2.html_components.SimpleComponents.Label import Label
 from AU2.html_components.SimpleComponents.LargeTextEntry import LargeTextEntry
 from AU2.html_components.SimpleComponents.NamedSmallTextbox import NamedSmallTextbox
@@ -416,6 +418,20 @@ def render(html_component, dependency_context={}):
         return {
             html_component.identifier: datetime.datetime.strptime(datetime_str, DATETIME_FORMAT).astimezone(TIMEZONE)}
 
+    elif isinstance(html_component, OptionalDatetimeEntry):
+        default = html_component.default.strftime(DATETIME_FORMAT) if html_component.default else ""
+        q = [inquirer.Text(
+            name="dt",
+            message=f"{escape_format_braces(html_component.title)} (YYYY-MM-DD HH:MM)",
+            default=default,
+            validate=optional_datetime_validator
+        )]
+        datetime_str = inquirer_prompt_with_abort(q)["dt"]
+        ts = (datetime.datetime.strptime(datetime_str, DATETIME_FORMAT).astimezone(TIMEZONE) if datetime_str
+              else None)
+        return {
+            html_component.identifier: ts}
+
     elif isinstance(html_component, IntegerEntry):
         q = [inquirer.Text(
             name="int",
@@ -425,6 +441,16 @@ def render(html_component, dependency_context={}):
         )]
         integer = inquirer_prompt_with_abort(q)["int"]
         return {html_component.identifier: int(integer)}
+
+    elif isinstance(html_component, FloatEntry):
+        q = [inquirer.Text(
+            name="float",
+            message=escape_format_braces(html_component.title),
+            default=html_component.default,
+            validate=float_validator
+        )]
+        number = inquirer_prompt_with_abort(q)["float"]
+        return {html_component.identifier: float(number)}
 
     elif isinstance(html_component, PathEntry):
         q = [inquirer.Path(

--- a/AU2/html_components/SimpleComponents/FloatEntry.py
+++ b/AU2/html_components/SimpleComponents/FloatEntry.py
@@ -1,7 +1,7 @@
 from AU2.html_components import HTMLComponent
 
 
-class IntegerEntry(HTMLComponent):
+class FloatEntry(HTMLComponent):
     name: str = "IntegerEntry"
 
     def __init__(self, identifier: str, title: str, default: int):

--- a/AU2/html_components/SimpleComponents/OptionalDatetimeEntry.py
+++ b/AU2/html_components/SimpleComponents/OptionalDatetimeEntry.py
@@ -1,0 +1,20 @@
+import datetime
+from typing import Optional
+
+from AU2.html_components import HTMLComponent
+from AU2.plugins.util.date_utils import get_now_dt
+
+
+class OptionalDatetimeEntry(HTMLComponent):
+    """Similar to DatetimeEntry but allows blank values"""
+    name: str = "OptionalDatetimeEntry"
+
+    def __init__(self, identifier: str, title: str, default: Optional[datetime.datetime] = None):
+        self.title = title
+        self.identifier = identifier
+        self.uniqueStr = self.get_unique_str()
+        self.default = default
+        super().__init__()
+
+    def _representation(self) -> str:
+        raise NotImplementedError()

--- a/AU2/plugins/custom_plugins/ScoringPlugin.py
+++ b/AU2/plugins/custom_plugins/ScoringPlugin.py
@@ -1,0 +1,263 @@
+import os
+from typing import List, Optional, Tuple, Any, Dict
+
+from AU2 import ROOT_DIR
+from AU2.database.AssassinsDatabase import ASSASSINS_DATABASE
+from AU2.database.EventsDatabase import EVENTS_DATABASE
+from AU2.database.GenericStateDatabase import GENERIC_STATE_DATABASE
+from AU2.html_components.HTMLComponent import HTMLComponent
+from AU2.html_components.SimpleComponents.Label import Label
+from AU2.html_components.SimpleComponents.OptionalDatetimeEntry import OptionalDatetimeEntry
+from AU2.html_components.SimpleComponents.DefaultNamedSmallTextbox import DefaultNamedSmallTextbox
+from AU2.html_components.SimpleComponents.FloatEntry import FloatEntry
+from AU2.html_components.SimpleComponents.HiddenTextbox import HiddenTextbox
+from AU2.plugins.AbstractPlugin import AbstractPlugin, Export, ConfigExport
+from AU2.plugins.CorePlugin import registered_plugin
+from AU2.plugins.constants import WEBPAGE_WRITE_LOCATION
+from AU2.plugins.util.ScoreManager import ScoreManager
+from AU2.plugins.util.date_utils import get_now_dt, timestamp_to_dt, dt_to_timestamp
+
+TABLE_TEMPLATE = """
+<table xmlns="" class="playerlist">
+  <tr><th>Real Name</th><th>Address</th><th>College</th><th>Water Weapons Status</th><th>Notes</th><th>Points</th></tr>
+  {ROWS}
+</table>
+"""
+
+ROW_TEMPLATE = """
+<tr><td>{NAME}</td><td>{ADDRESS}</td><td>{COLLEGE}</td><td>{WATER_STATUS}</td><td>{NOTES}</td><td>{POINTS:g}</tr>
+"""
+
+OPENSEASON_PAGE_TEMPLATE: str
+with open(os.path.join(ROOT_DIR, "plugins", "custom_plugins", "html_templates", "openseason.html"), "r", encoding="utf-8",
+          errors="ignore") as F:
+    OPENSEASON_PAGE_TEMPLATE = F.read()
+
+@registered_plugin
+class ScoringPlugin(AbstractPlugin):
+    def __init__(self):
+        super().__init__("ScoringPlugin")
+
+        self.html_ids = {
+            "Start": self.identifier + "_openseason_start",
+            "Formula": self.identifier + "_formula",
+            "Bonus": self.identifier + "_bonus",
+            "Assassin": self.identifier + "_assassin"
+        }
+
+        self.plugin_state = {
+            "Start": {'id': self.identifier + "_openseason_start", 'default': None},
+            "Formula": {'id': self.identifier + "_score_formula", 'default': ''}
+        }
+
+        self.assassin_plugin_state = {
+            "Bonus": {'id': self.identifier + "_bonus", 'default': 0}
+        }
+
+        self.exports = [
+            Export(
+                "scoring_set_bonuses",
+                "Scoring -> Set bonuses",
+                self.ask_set_bonuses,
+                self.answer_set_bonuses,
+                (self.gather_assassins_and_bonuses,)
+            )
+        ]
+
+        self.config_exports = [
+            ConfigExport(
+                "scoring_start_open_season",
+                "Scoring -> Set Open Season start",
+                self.ask_start_open_season,
+                self.answer_start_open_season
+            ),
+            ConfigExport(
+                "scoring_set_formula",
+                "Scoring -> Set formula",
+                self.ask_set_formula,
+                self.answer_set_formula
+            ),
+        ]
+
+    # plugin state management is copied from PolicePlugin
+    def gsdb_get(self, plugin_state_id: str):
+        return GENERIC_STATE_DATABASE.arb_state.get(self.identifier, {}).get(self.plugin_state[plugin_state_id]['id'],
+                                                                             self.plugin_state[plugin_state_id][
+                                                                                 'default'])
+
+    def gsdb_set(self, plugin_state_id: str, data: Any):
+        GENERIC_STATE_DATABASE.arb_state.setdefault(self.identifier, {})[
+            self.plugin_state[plugin_state_id]['id']] = data
+
+    def gsdb_remove(self, plugin_state_id: str):
+        """Removes a plugin state key from the gsdb, i.e. reverts to default"""
+        GENERIC_STATE_DATABASE.arb_state.setdefault(self.identifier, {}).pop(self.plugin_state[plugin_state_id]['id'],
+                                                                             None)
+
+    # does similar to above but for Assassin.plugin_state
+    def aps_get(self, assassin_id: str, plugin_state_id: str) -> Any:
+        assassin = ASSASSINS_DATABASE.get(assassin_id)
+        return assassin.plugin_state.get(self.identifier, {}).get(self.assassin_plugin_state[plugin_state_id]['id'],
+                                                                  self.assassin_plugin_state[plugin_state_id][
+                                                                      'default'])
+
+    def aps_set(self, assassin_id: str, plugin_state_id: str, data: Any):
+        assassin = ASSASSINS_DATABASE.get(assassin_id)
+        assassin.plugin_state.setdefault(self.identifier, {})[self.assassin_plugin_state[plugin_state_id]['id']] = data
+
+    def gather_assassins_and_bonuses(self) -> List[Tuple[str, str]]:
+        """Lists assassins with their bonuses"""
+        return [(f"{ident} -- {self.aps_get(ident, 'Bonus')}", ident)
+                for ident in ASSASSINS_DATABASE.get_identifiers()]
+
+    def ask_set_bonuses(self, ident: str) -> List[HTMLComponent]:
+        current_bonus = self.aps_get(ident, "Bonus")
+        components = [
+            HiddenTextbox(
+                identifier=self.html_ids["Assassin"],
+                default=ident
+            ),
+            FloatEntry(
+                identifier=self.html_ids["Bonus"],
+                title="Bonus points",
+                default=current_bonus
+            )
+        ]
+        return components
+
+    def answer_set_bonuses(self, html_response: Dict[str, Any]) -> List[HTMLComponent]:
+        new_bonus = html_response[self.html_ids["Bonus"]]
+        ident = html_response[self.html_ids["Assassin"]]
+        self.aps_set(ident, "Bonus", new_bonus)
+        return [Label("[SCORING] Set bonus.")]
+
+    def ask_start_open_season(self):
+        ts = self.gsdb_get("Start")
+        return [
+            OptionalDatetimeEntry(identifier=self.html_ids["Start"],
+                          title="Enter when Open Season should start (blank for \"never\")",
+                          default=timestamp_to_dt(ts) if ts else get_now_dt())
+        ]
+
+    def answer_start_open_season(self, html_response):
+        start = html_response[self.html_ids["Start"]]
+        if start:
+            self.gsdb_set("Start", dt_to_timestamp(start))
+        else:
+            self.gsdb_remove("Start")
+        return [Label("[SCORING] Set open season start.")]
+
+    def ask_set_formula(self):
+        # TODO: have a Formula component that validates the formula,
+        #       and give detail on formula syntax
+        return [
+            Label("""Scoring formula instructions:
+Parameters:
+    a: attempts
+    b: bonus points -- awarded manually using Scoring -> Set bonuses
+    k: kills -- excludes kills of police, and of players who had already died when the kill was made
+    c: conkers -- a player's conkers score is the number of kills made by the player, plus the sum of \
+the conkers of all players killed by the player, ignoring any kills that do not count towards the kill score \
+as defined above
+
+Syntax:
+    Currently the scoring formula is passed directly to the Python eval() function.
+    This means the syntax is that of a Python expression.
+    For reference, the arithmetic symbols are
+        + addition
+        - subtraction
+        * multiplication
+        / division
+        ** exponentiation
+    If you want to be fancy, `import math` is run right before the formula is evaluated,
+    so you can use functions from this module too.
+"""),
+            DefaultNamedSmallTextbox(identifier=self.html_ids["Formula"],
+                                     title="Scoring formula",
+                                     default=self.gsdb_get("Formula"))
+        ]
+
+    def answer_set_formula(self, html_response):
+        self.gsdb_set("Formula", html_response[self.html_ids["Formula"]])
+        return [Label("[SCORING] Set scoring formula.")]
+
+    def formula_is_valid(self, formula: Optional[str] = None) -> bool:
+        """
+        Checks whether the scoring formula is valid.
+
+        Parameters:
+            formula: the scoring formula in string form. Defaults to the value from the plugin.
+
+        Returns:
+            True if formula is valid, False otherwise
+        """
+        if formula is None:
+            formula = self.gsdb_get("Formula")
+        # since we don't have the formula parser yet,
+        # we crudely use a try-except evaluating the expression
+        a = 0
+        b = 0
+        c = 0
+        k = 0
+        import math
+        try:
+            eval(formula)
+            return True
+        except Exception:
+            return False
+
+    def on_page_generate(self, _) -> List[HTMLComponent]:
+        # don't generate open season page if open season hasn't started!
+        open_season_start = timestamp_to_dt(self.gsdb_get("Start"))
+        if not open_season_start or open_season_start >= get_now_dt():
+            return []
+
+        # also don't generate if formula is invalid
+        formula = self.gsdb_get("Formula")
+        if not self.formula_is_valid(formula):
+            return [Label("[WARNING] [SCORING] Invalid scoring formula -- skipping openseason page!")]
+
+        # need to include hidden assassins so that resurrecting as police doesn't stop kills counting
+        score_manager = ScoreManager(ASSASSINS_DATABASE.get_identifiers(include=lambda a: not a.is_police,
+                                                                        include_hidden=lambda a: not a.is_police),
+                                     formula=formula,
+                                     bonuses={
+                                         ident: self.aps_get(ident, "Bonus")
+                                         for ident in ASSASSINS_DATABASE.get_identifiers()
+                                     })
+        events = sorted(EVENTS_DATABASE.events.values(),
+                        key=lambda e: e.datetime)
+        for e in events:
+            score_manager.add_event(e)
+
+        table_str = "Something went wrong..."
+        if score_manager.live_assassins:
+            # score_manager caches score, so calling twice is fine!
+            # *negative* of score is used for sorting so that high scorers end up at the top of the page
+            live_assassins = sorted((ASSASSINS_DATABASE.get(ident) for ident in score_manager.live_assassins
+                                     if not ASSASSINS_DATABASE.get(ident).hidden),
+                                    key=lambda a: (-score_manager.get_score(a), a.college.lower(), a.real_name.lower()))
+            rows = []
+            for a in live_assassins:
+                rows.append(
+                    ROW_TEMPLATE.format(
+                        NAME=a.real_name,
+                        ADDRESS=a.address,
+                        COLLEGE=a.college,
+                        WATER_STATUS=a.water_status,
+                        NOTES=a.notes,
+                        POINTS=score_manager.get_score(a)
+                    )
+                )
+            table_str = TABLE_TEMPLATE.format(ROWS="".join(rows))
+
+        with open(os.path.join(WEBPAGE_WRITE_LOCATION, "openseason.html"), "w+", encoding="utf-8") as F:
+            F.write(
+                OPENSEASON_PAGE_TEMPLATE.format(
+                    YEAR=get_now_dt().year,
+                    TABLE=table_str
+                )
+            )
+
+        return [Label("[SCORING] Success!")]
+

--- a/AU2/plugins/custom_plugins/html_templates/openseason.html
+++ b/AU2/plugins/custom_plugins/html_templates/openseason.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<link rel="preconnect" href="https://fonts.googleapis.com">
+	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+	<link href="https://fonts.googleapis.com/css2?family=Aref+Ruqaa+Ink:wght@700&family=Roboto+Slab&display=swap" rel="stylesheet">
+	<link rel="stylesheet" type="text/css" href="newassassins.css">
+ 	<link rel="shortcut icon" href="img/cloak3.png">
+	<script src="main.js"></script>
+ 	<title>The Assassins' Guild</title>
+</head>
+<body>
+<div class="backgroundimg">
+<div class="wrapper">
+
+	<div w3-include-html="header.html"></div>
+
+
+	<!--Main Content-->   <h2>Open Season</h2>
+	<p>If you've survived this far, all players here are licit targets for you. Only the top scoring players will make it through the the duel.</p>
+	<h3>Killing high scoring players will generally yield more points than killing low scoring players.</h3>
+
+    {TABLE}
+
+<!--Footer-->
+	<div class="footer">
+		<h5>Assassins' Guild {YEAR}</h5>
+	</div>
+</div>
+</div>
+
+<script>
+	includeHTML();
+</script>
+</body></html>

--- a/AU2/plugins/util/ScoreManager.py
+++ b/AU2/plugins/util/ScoreManager.py
@@ -1,0 +1,71 @@
+import functools
+from collections import defaultdict
+from typing import Dict, List, Set, Optional
+
+from AU2.database.model import Event, Assassin
+# TODO: from ??? import calculate_formula
+
+
+class ScoreManager:
+    def __init__(self,
+                 assassin_ids: List[str],
+                 formula: str = "",
+                 bonuses: Dict[str, int] = {},
+                 perma_death=True):
+        self.kill_tree: Dict[str, List[str]] = {}
+        self.attempt_counter: Dict[str, int] = {}
+        self.live_assassins = set(assassin_ids)
+        self.formula = formula
+        self.bonuses = bonuses
+        self.perma_death = perma_death
+
+    def add_event(self, e: Event):
+        # adding an event invalidates the cache
+        self._score.cache_clear()
+        for (killer, victim) in e.kills:
+            # in regular games, live_assassins will initially only include non-police,
+            # and dead players will be pruned as events are added
+            if victim not in self.live_assassins:
+                continue
+            self.kill_tree.setdefault(killer, []).append(victim)
+            if self.perma_death:
+                self.live_assassins.discard(victim)
+        for assassin_id in e.pluginState.get("CompetencyPlugin", {}).get("attempts", []):
+            self.attempt_counter[assassin_id] = self.attempt_counter.get(assassin_id, 0) + 1
+
+    def _conkers(self, identifier: str, visited: Optional[Set[str]] = None) -> int:
+        if visited is None: # need to do this because we mutate visited
+            visited = set()
+        # prevent the same player giving conkers twice via different paths through the kill tree
+        # (and also deals with loops. note that players can't get conkers from themselves;
+        # we may wish to change this for a "revenge bonus")
+        # both of these should only happen without perma-deat
+        if identifier in visited:
+            return -1  # cancels out the `1 +` in this term of the sum
+        else:
+            visited.add(identifier)
+        return sum((1 + self._conkers(v, visited) for v in self.kill_tree.get(identifier, [])))
+
+    def _kills(self, identifier: str) -> int:
+        return len(self.kill_tree.get(identifier, []))
+
+    def _attempts(self, identifier: str) -> int:
+        return self.attempt_counter.get(identifier, 0)
+
+    def _bonus(self, identifier: str) -> float:
+        return self.bonuses.get(identifier, 0)
+
+    @functools.cache
+    def _score(self, identifier: str) -> float:
+        # placeholder!
+        # TODO: should use Jamie's formula parser to calculate score
+        k = self._kills(identifier)
+        c = self._conkers(identifier)
+        b = self._bonus(identifier)
+        a = self._attempts(identifier)
+        import math
+        score = eval(self.formula)
+        return score
+
+    def get_score(self, a: Assassin) -> float:
+        return self._score(a.identifier)

--- a/AU2/plugins/util/date_utils.py
+++ b/AU2/plugins/util/date_utils.py
@@ -1,7 +1,20 @@
 import datetime
+from typing import Optional
 
 from AU2 import TIMEZONE
 
 
 def get_now_dt():
    return datetime.datetime.now().astimezone(TIMEZONE)
+
+# global datetime <-> timestamp conversion functions to ensure consistency
+# supports "optional datetimes" comnverting `None` to `None`
+def timestamp_to_dt(ts: Optional[float]) -> Optional[datetime.datetime]:
+   if ts is None:
+      return None
+   return datetime.datetime.fromtimestamp(ts).astimezone().astimezone(TIMEZONE)
+
+def dt_to_timestamp(ts: Optional[datetime.datetime]) -> Optional[float]:
+   if ts is None:
+      return None
+   return ts.timestamp()

--- a/AU2/test/plugins/util/custom_plugins/test_ScoringPlugin.py
+++ b/AU2/test/plugins/util/custom_plugins/test_ScoringPlugin.py
@@ -1,0 +1,241 @@
+import random
+import math
+from typing import Dict
+
+from AU2.database.AssassinsDatabase import ASSASSINS_DATABASE
+from AU2.database.EventsDatabase import EVENTS_DATABASE
+from AU2.plugins.custom_plugins.ScoringPlugin import ScoringPlugin
+from AU2.plugins.util.ScoreManager import ScoreManager
+from AU2.test.test_utils import MockGame, some_players, plugin_test, dummy_event
+
+
+class TestScoringPlugin:
+
+    def get_manager(self, mockGame, perma_death: bool = True, filter_police = True) -> ScoreManager:
+        m = ScoreManager(assassin_ids=[name + " identifier" for name in mockGame.all_assassins
+                                       if not (filter_police and mockGame.assassin_model(name).is_police)],
+                         perma_death=perma_death)
+        for e in sorted(EVENTS_DATABASE.events.values(), key=lambda e: e.datetime):
+            m.add_event(e)
+        return m
+
+    def random_attempts(self, game: MockGame) -> Dict[str, int]:
+        """
+        Adds random attempts to `game` and returns a dict of the correct number of attempts for each assassin
+        """
+        players = game.get_remaining_players()
+        n_players = len(players)
+        n_events = abs(math.floor(random.normalvariate(n_players, n_players/3)))
+        attempts_map = {}
+        for i in range(n_events):
+            attempters = set(random.choices(players, k=math.ceil(random.expovariate(1))))
+            others = set(random.choices(players, k=math.ceil(random.expovariate(1/3)))) - attempters
+            game.add_attempts(*attempters, others=list(others))
+            for a in attempters:
+                attempts_map[a] = attempts_map.get(a, 0) + 1
+        return attempts_map
+
+    @plugin_test
+    def test_scoring_params_1(self):
+        """
+        Test game 1: chain of kills
+        Kill tree looks like
+        n-1 -> n-2 -> ... -> 1 -> 0
+        """
+        n = 50
+        p = some_players(n)
+        game = MockGame().having_assassins(p)
+        idents = [name + " identifier" for name in p]
+
+        attempts_map = self.random_attempts(game)
+
+        # add chain of kills
+        for i in range(1, n):
+            game.assassin(p[i]).kills(p[i-1]).new_datetime()
+
+        # hide some players (not player n-1) -- their kills should still be counted!
+        for i in random.choices(range(0, n-1), k = 1 + n // 10):
+            game.assassin(p[i]).is_hidden()
+
+        manager = self.get_manager(game)
+        # kills should equal 1 for each except player 0
+        for i in range(1, n):
+            assert manager._kills(idents[i]) == 1
+        assert manager._kills(idents[0]) == 0
+
+        # conker should be 0 for player 0 (no kills),
+        # then 1 for player 1, increasing by 1 as we go up the chain of kills
+        # i.e. should equal the index of the player in this mock game
+        for i in range(n):
+            assert manager._conkers(idents[i]) == i
+
+        # check attempts manager tracks attempts correctly
+        for i in range(n):
+            assert manager._attempts(idents[i]) == attempts_map.get(p[i], 0)
+
+        # only one player should be alive in this game, namely p[n-1]
+        assert manager.live_assassins == {idents[n-1]}
+
+    @plugin_test
+    def test_scoring_params_2(self):
+        """
+        Test game 2: binary kill tree
+        kill tree looks like
+        0 -> 1 -> 3 -> 7
+          |    |    |
+          |    |    -> 8
+          |    |
+          |    -> 4 -> 9
+          |         |
+          |         -> 10
+          |
+          -> 2 -> 5 -> 11
+               |    |
+               |    -> 12
+               |
+               -> 6 -> 13
+                    |
+                    -> 14
+        """
+        n = 15
+        p = some_players(n)
+        game = MockGame().having_assassins(p)
+        idents = [name + " identifier" for name in p]
+
+        attempts_map = self.random_attempts(game)
+
+        # mix of kills in same events and across events,
+        game.assassin(p[6]).kills(p[13], p[14]).new_datetime()
+        game.assassin(p[5]).kills(p[11]).assassin(p[5]).kills(p[12]).new_datetime()
+
+        game.assassin(p[2]).kills(p[5]).new_datetime()
+
+        game.assassin(p[4]).kills(p[9], p[10]).new_datetime()
+        game.assassin(p[3]).kills(p[7]).assassin(p[3]).kills(p[8]).new_datetime()
+
+        game.assassin(p[2]).kills(p[6]).new_datetime()
+        game.assassin(p[1]).kills(p[3], p[4]).new_datetime()
+
+        game.assassin(p[0]).kills(p[1], p[2]).new_datetime()
+
+        # hide some players (not 0) -- their kills should still be counted!
+        for i in random.choices(range(1, n), k = 1 + n // 5):
+            game.assassin(p[i]).is_hidden()
+
+        manager = self.get_manager(game)
+
+        # check kills are counted correctly
+        for i in range(0, 7):
+            assert manager._kills(idents[i]) == 2
+        for i in range(7, 15):
+            assert manager._kills(idents[i]) == 0
+
+        # check conkers calculated correctly
+        assert manager._conkers(idents[0]) == 14
+        for i in range(1, 3):
+            assert manager._conkers(idents[i]) == 6
+        for i in range(3, 6):
+            assert manager._conkers(idents[i]) == 2
+        for i in range(7, 15):
+            assert manager._conkers(idents[i]) == 0
+
+        # check attempts counted correctly
+        for i in range(15):
+            assert manager._attempts(idents[i]) == attempts_map.get(p[i], 0)
+
+        # only one player should be alive in this game, namely p[0]
+        assert manager.live_assassins == {idents[0]}
+
+    @plugin_test
+    def test_looped_killtree(self):
+        """
+        Tests whether conkers are calculated correctly when loops are involved in the kill graph
+        (with perma-death turned off)
+        Kill graph used is
+            0 <-> 1 -> 2
+                 /|\   |
+                  |   \|/
+                  4 <- 3
+        """
+        p = some_players(5)
+        idents = [name + " identifier" for name in p]
+        game = MockGame().having_assassins(p)
+
+        # construct kill graph
+        game.assassin(p[3]).kills(p[4]).new_datetime()
+        game.assassin(p[2]).kills(p[3]).new_datetime()
+        game.assassin(p[1]).kills(p[2]).new_datetime()
+        game.assassin(p[4]).kills(p[1]).new_datetime()
+        game.assassin(p[0]).kills(p[1]).new_datetime()
+        game.assassin(p[1]).kills(p[0]).new_datetime()
+
+        manager = self.get_manager(game, perma_death=False)
+
+        # check kills are counted correctly
+        for i in range(0, 5):
+            if i == 1:
+                assert manager._kills(idents[i]) == 2
+            else:
+                assert manager._kills(idents[i]) == 1
+
+        # check conkers calculated correctly
+        # note that players do not get conkers from themselves!
+        # (could change this as a revenge bonus?)
+        for i in range(5):
+            assert manager._conkers(idents[i]) == 4
+
+        # check all players still counted as live (since no perma-death)
+        assert manager.live_assassins == set(idents)
+
+    @plugin_test
+    def test_double_death_and_police(self):
+        """
+        Kill tree is
+                 7 -> 6
+                      |
+                     \|/
+            4 -> 0 -> 1 -> 3
+                     /|\
+                      |
+                 5 -> 2
+        where 3 and 7 are police and 0 killed 1 first.
+        (this models the situation where a player went wanted then three people killed them in quick succession)
+        """
+        n = 8
+        p = some_players(n)
+        game = MockGame().having_assassins(p)
+        idents = [name + " identifier" for name in p]
+
+        game.assassin(p[3]).with_accomplices(p[7]).are_police()
+        game.assassin(p[1]).kills(p[3]).new_datetime()
+        game.assassin(p[0]).kills(p[1]).new_datetime()
+        game.assassin(p[2]).kills(p[1]).new_datetime()
+        game.assassin(p[6]).kills(p[1]).new_datetime()
+        game.assassin(p[5]).kills(p[2]).new_datetime()
+        game.assassin(p[4]).kills(p[0]).new_datetime()
+        game.assassin(p[7]).kills(p[6])
+
+        manager = self.get_manager(game)
+
+        # check kills are counted correctly
+        for i in range(0, n):
+            if i in {0, 4, 5}:
+                assert manager._kills(idents[i]) == 1
+            elif i in {3, 7}:
+                continue # we don't care about police kill counts
+            else:
+                assert manager._kills(idents[i]) == 0
+
+        # check conkers are calculated correctly
+        for i in range(0, n):
+            if i in {0, 5}:
+                assert manager._conkers(idents[i]) == 1
+            elif i in {4}:
+                assert manager._conkers(idents[i]) == 2
+            elif i in {3, 7}:
+                continue # we don't care about police conkers
+            else:
+                assert manager._conkers(idents[i]) == 0
+
+        # check the open season list is correct
+        assert manager.live_assassins == {idents[4], idents[5]}


### PR DESCRIPTION
Adds a plugin to generate the Open Season page. The plugin includes config options to set the start of open season and the scoring formula. The start of open season determines whether the open season page is generated when using `Generate Pages`. If the start of open season is unset it defaults to assuming open season has *not* started.

~~The scoring formula is not used yet as I was waiting on @jsyiek 's solution to #31.~~ As a hotfix an `eval()` is used to parse the scoring formula.

The plugin uses a `ScoreManager` to calculate the kills, attempts, and conkers of each player; I have written a couple of automated tests already but it could perhaps do with more. I have also tested generating the open season page with the current game database, alternately using conkers, kills, and attempts as a placeholder for the score, and it deals with it fine, though the accuracy of the values is yet to be determined...