### PR TITLE
Implemented `DangerousConfigExport`

### DIFF
--- a/AU2/frontends/inquirer_cli.py
+++ b/AU2/frontends/inquirer_cli.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import copy
 import datetime
+import os
 import tabulate
 from typing import List, Any, Dict
 
@@ -708,6 +709,16 @@ def replace_overrides(component_list: List[HTMLComponent], existing_overrides={}
 
 
 def main():
+    # allow ANSI codes to work on old Windows terminals
+    # but don't let not having the module break the program!
+    try:
+        from colorama import just_fix_windows_console
+        just_fix_windows_console()
+    except ModuleNotFoundError:
+        if os.name == "nt":
+            print("[WARNING] `colorama` is not installed; if you are using an old terminal, "
+                  "colours may not render correctly.")
+
     while True:
         core_plugin: CorePlugin = PLUGINS["CorePlugin"]
         exports = core_plugin.get_all_exports()

--- a/AU2/frontends/inquirer_cli.py
+++ b/AU2/frontends/inquirer_cli.py
@@ -2,6 +2,7 @@
 import copy
 import datetime
 import os
+import random
 import tabulate
 from typing import List, Any, Dict
 
@@ -40,7 +41,8 @@ from AU2.html_components.SimpleComponents.PathEntry import PathEntry
 from AU2.html_components.SimpleComponents.SelectorList import SelectorList
 from AU2.html_components.SpecialComponents.EditablePseudonymList import EditablePseudonymList, PseudonymData, \
     ListUpdates
-from AU2.plugins.AbstractPlugin import Export
+from AU2.html_components.SpecialComponents.ConfigOptionsList import ConfigOptionsList
+from AU2.plugins.AbstractPlugin import Export, DangerousConfigExport
 from AU2.plugins.CorePlugin import PLUGINS, CorePlugin
 from AU2.plugins.util.date_utils import get_now_dt
 from AU2.plugins.util.game import escape_format_braces
@@ -651,6 +653,27 @@ def render(html_component, dependency_context={}):
             ]
             return inquirer_prompt_with_abort(q)
 
+    elif isinstance(html_component, ConfigOptionsList):
+        # render dangerous config exports in red
+        choices = [("\033[31m" + c.display_name + "\033[0m", c) if isinstance(c, DangerousConfigExport)
+                   else (c.display_name, c)
+                   for c in html_component.config_options]
+        selection = inquirer.list_input(
+                message=escape_format_braces(html_component.title),
+                choices=["*EXIT*"] + choices
+        )
+        if selection == "*EXIT*":
+            raise KeyboardInterrupt
+
+        if isinstance(selection, DangerousConfigExport):
+            # give explanation of why confirmation needed
+            print(selection.explanation)
+            i = random.randint(0, 1000000)
+            if str(i) != inquirer.text(f"Type {i} to access this config option"):
+                raise KeyboardInterrupt
+
+        return {html_component.identifier: selection}
+
     else:
         raise Exception("Unknown component type:", type(html_component))
 
@@ -740,24 +763,35 @@ def main():
                 break
 
         params = []
-        qs = []
-        i = 0
+        kwargs = {}
+        abort = False
         for f in exp.options_functions:
-            qs.append(inquirer.List(name=i, choices=["*EXIT*"] + f(),
-                                    ignore=lambda x: any(a[j] == "*EXIT*" for j in range(i))))
-            i += 1
-        if qs:
+            options = f(*params)
+            fallback = isinstance(options, list)
+            if fallback:
+                options = InputWithDropDown(identifier="options",
+                                            title="",
+                                            options=["*EXIT*"] + options)
             try:
-                a = inquirer_prompt_with_abort(qs)
+                result = render(options)
             except KeyboardInterrupt:
-                continue
-            if any(a[k] == "*EXIT*" for k in range(i)):
-                continue
-            for k in range(i):
-                params.append(a[k])
+                abort = True
+                break
+
+            if fallback:
+                selection = result["options"]
+                abort = selection == "*EXIT*"
+                if abort:
+                    break
+                params.append(selection)
+            else:
+                kwargs.update(result)
+
+        if abort:
+            continue
 
         inp = {}
-        components = exp.ask(*params)
+        components = exp.ask(*params, **kwargs)
         components = replace_overrides(components)
         components = merge_dependency(components)
         iteration = 0

--- a/AU2/html_components/SpecialComponents/ConfigOptionsList.py
+++ b/AU2/html_components/SpecialComponents/ConfigOptionsList.py
@@ -1,0 +1,30 @@
+from typing import List
+
+from AU2.html_components import HTMLComponent
+from AU2.plugins.AbstractPlugin import ConfigExport
+
+
+class ConfigOptionsList(HTMLComponent):
+    """
+    Special component used for the plugin config selector,
+    so that we can deal with DangerousConfigOptions correctly.
+    How these are rendered specifically is left up to the front-end; inquirer_cli simply colours them red
+    """
+
+    name = "ConfigOptionsList"
+
+    def __init__(self, identifier: str, title: str, config_options: List[ConfigExport]):
+        """
+        Args:
+            identifier: internal identifier
+            title: visible label for the component
+            config_options: list of ConfigExports to display. The front-end will deal with rendering
+                `DangerousConfigExport`s correctly.
+        """
+        self.identifier = identifier
+        self.title = title
+        self.config_options = config_options
+        super().__init__()
+
+    def _representation(self) -> str:
+        raise NotImplementedError()

--- a/AU2/plugins/AbstractPlugin.py
+++ b/AU2/plugins/AbstractPlugin.py
@@ -1,5 +1,7 @@
 from typing import List, Tuple
 
+import termcolor
+
 from AU2.database.model import Event, Assassin
 from AU2.html_components import HTMLComponent
 
@@ -45,6 +47,11 @@ class ConfigExport(Export):
             answer
         )
 
+class DangerousConfigExport(ConfigExport):
+    """
+    Represents a config export which shouldn't be changed while a game is in progress
+    This is signalled to the user by colouring the option red
+    """
 
 class HookedExport:
     """

--- a/AU2/plugins/AbstractPlugin.py
+++ b/AU2/plugins/AbstractPlugin.py
@@ -1,6 +1,4 @@
-from typing import List, Tuple
-
-import termcolor
+from typing import List, Tuple, Union, Any, Callable
 
 from AU2.database.model import Event, Assassin
 from AU2.html_components import HTMLComponent
@@ -11,13 +9,28 @@ class Export:
     Represents an HTML callback
     """
 
-    def __init__(self, identifier: str, display_name: str, ask, answer, options_functions: Tuple = tuple()):
+    def __init__(self, identifier: str, display_name: str, ask, answer,
+                 options_functions: Tuple[Callable[
+                     [...],
+                     Union[
+                         List[Union[str, Tuple[str, Any]]],
+                         HTMLComponent
+                     ]
+                 ]] = tuple()):
         """
-        :param identifier: internal identifier for the callback
-        :param display_name: html-visible display name
-        :param ask: function that generates a list of HTML components
-        :param answer: function that takes a dictionary of arg -> str and actions the output
-        :param options: list of options to include alongside the export (will result in a string being passed as an arg)
+        Args:
+            identifier: internal identifier for the callback
+            display_name: html-visible display name
+            ask: function that generates a list of HTML components
+            answer: function that takes a dictionary of arg -> str and actions the output
+            options_functions: tuple of functions each returning either a HTMLComponent or a list of options;
+                The functions are executed in the order that they appear in this tuple. If a HTMLComponent is returned,
+                this will be rendered, and the result passed as a keyword argument based on the identifier to subsequent
+                functions in the tuple as well as the `ask` function.
+                If a list is returned then we fall back to rendering a selection from the options in that list, and the
+                result is passed as a positional argument to subsequent functions in the tuple as well as the `ask`
+                function.
+
         """
         self.identifier = identifier
         self.display_name = display_name
@@ -26,12 +39,15 @@ class Export:
         self.options_functions = options_functions
 
 
+DEFAULT_DCE_EXPLANATION = "This config option is dangerous to modify after a game has started."
+
 class ConfigExport(Export):
     """
     Represents a callback for a configuration parameter.
     """
 
-    def __init__(self, identifier: str, display_name: str, ask, answer):
+    def __init__(self, identifier: str, display_name: str, ask, answer,
+                 explanation: str = DEFAULT_DCE_EXPLANATION):
         """
         Unlike Export, this bans the options function as there are only two stages to Config.
 
@@ -39,7 +55,9 @@ class ConfigExport(Export):
         :param display_name: html-visible display name
         :param ask: function that generates a list of HTML components
         :param answer: function that takes a dictionary of arg -> str and actions the output
+
         """
+        self.explanation = explanation
         super().__init__(
             identifier,
             display_name,

--- a/AU2/plugins/custom_plugins/CompetencyPlugin.py
+++ b/AU2/plugins/custom_plugins/CompetencyPlugin.py
@@ -19,7 +19,7 @@ from AU2.html_components.SimpleComponents.Label import Label
 from AU2.html_components.SimpleComponents.SelectorList import SelectorList
 from AU2.html_components.SimpleComponents.Table import Table
 from AU2.html_components.SimpleComponents.NamedSmallTextbox import NamedSmallTextbox
-from AU2.plugins.AbstractPlugin import AbstractPlugin, ConfigExport, Export
+from AU2.plugins.AbstractPlugin import AbstractPlugin, ConfigExport, Export, DangerousConfigExport
 from AU2.plugins.CorePlugin import registered_plugin
 from AU2.plugins.constants import WEBPAGE_WRITE_LOCATION
 from AU2.plugins.custom_plugins.SRCFPlugin import Email
@@ -126,7 +126,7 @@ class CompetencyPlugin(AbstractPlugin):
                 ask=self.set_default_competency_deadline_ask,
                 answer=self.set_default_competency_deadline_answer
             ),
-            ConfigExport(
+            DangerousConfigExport(
                 identifier="CompetencyPlugin_auto_competency",
                 display_name="Competency -> Change Auto Competency",
                 ask=self.ask_auto_competency,

--- a/AU2/plugins/custom_plugins/CompetencyPlugin.py
+++ b/AU2/plugins/custom_plugins/CompetencyPlugin.py
@@ -132,7 +132,7 @@ class CompetencyPlugin(AbstractPlugin):
                 ask=self.ask_auto_competency,
                 answer=self.answer_auto_competency
             ),
-            ConfigExport(
+            DangerousConfigExport(
                 identifier="CompetencyPlugin_attempt_tracking",
                 display_name="Competency -> Toggle Attempt Tracking",
                 ask=lambda *args: [],

--- a/AU2/plugins/custom_plugins/TargetingPlugin.py
+++ b/AU2/plugins/custom_plugins/TargetingPlugin.py
@@ -10,7 +10,7 @@ from AU2.html_components import HTMLComponent
 from AU2.html_components.SimpleComponents.IntegerEntry import IntegerEntry
 from AU2.html_components.SimpleComponents.Label import Label
 from AU2.html_components.SimpleComponents.SelectorList import SelectorList
-from AU2.plugins.AbstractPlugin import AbstractPlugin, Export, ConfigExport
+from AU2.plugins.AbstractPlugin import AbstractPlugin, Export, DangerousConfigExport
 from AU2.plugins.CorePlugin import registered_plugin
 from AU2.plugins.custom_plugins.SRCFPlugin import Email
 
@@ -57,13 +57,13 @@ class TargetingPlugin(AbstractPlugin):
         ]
 
         self.config_exports = [
-            ConfigExport(
+            DangerousConfigExport(
                 "targeting_set_player_seeds",
                 "Targeting Graph -> Set player seeds",
                 self.ask_set_seeds,
                 self.answer_set_seeds
             ),
-            ConfigExport(
+            DangerousConfigExport(
                 "targeting_set_random_seed",
                 "Targeting Graph -> Set random seed",
                 self.ask_set_random_seed,

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ inquirer
 datetime
 paramiko
 tabulate
+colorama # optional -- only needed if using an old Windows terminal


### PR DESCRIPTION
**Problem:** Certain config options (mainly to do with targeting) break the game if changed after a game has started. It would be useful to communicate this to users.

**Solution:** Have a subclass of `ConfigExport` called `DangerousConfigExport`, and have these coloured red in `Plugin config -> Plugin-specific parameters`. The config options I have classed as being dangerous are
- `Competency -> Change Auto Competency`
- `Targeting Graph -> Set player seeds`
- `Targeting Graph -> Set random seed`

**Remarks:**` gather_config_names` had to be reworked since otherwise the ANSI codes messed with the ordering of the config options. The module`colorama` is used in `inquirer_cli` to ensure the ANSI codes are rendered correctly on Windows (this is only an issue for older terminals), but not having it installed will only cause a warning rather than a crash.

