### PR TITLE
[80] Sanity checking framework

### DIFF
--- a/AU2/plugins/sanity_checks/MissingHtmlSpecifier.py
+++ b/AU2/plugins/sanity_checks/MissingHtmlSpecifier.py
@@ -1,0 +1,51 @@
+from typing import List
+
+from AU2.database.AssassinsDatabase import ASSASSINS_DATABASE
+from AU2.database.model import Event
+from AU2.html_components import HTMLComponent
+from AU2.html_components.SimpleComponents.Label import Label
+from AU2.plugins.sanity_checks.model.SanityCheck import SanityCheck
+from AU2.plugins.sanity_checks.model.SanityCheck import Suggestion
+from AU2.plugins.util.game import HTML_REPORT_PREFIX
+
+
+class MissingHtmlSpecifier(SanityCheck):
+
+    identifier = "Missing_HTML_Specifier"
+
+    html_indicators = [
+        "<br>",
+        "<b>",
+        "<html>",
+        "<em>"
+    ]
+
+    def suggest_event_fixes(self, e: Event) -> List[Suggestion]:
+        suggestions = []
+        for i, (assassin, pseudonym_id, report) in enumerate(e.reports):
+            if any(h in report for h in self.html_indicators) and HTML_REPORT_PREFIX not in report:
+                name = ASSASSINS_DATABASE.assassins[assassin].real_name
+                suggestions.append(
+                    Suggestion(
+                        explanation=f"Enable HTML in {name}'s report (id={i})",
+                        identifier=f"{i}"
+                    )
+                )
+        return suggestions
+
+    def fix_event(self, e: Event, suggestion_ids: List[str]) -> List[HTMLComponent]:
+        suggestion_ids = sorted([int(s) for s in suggestion_ids])
+        fix_ptr = 0
+        labels = []
+        for i, (assassin, pseudonym_id, report) in enumerate(e.reports):
+            if i == suggestion_ids[fix_ptr]:
+                fix_ptr += 1
+                report = HTML_REPORT_PREFIX + report
+                e.reports[i] = (assassin, pseudonym_id, report)
+                name = ASSASSINS_DATABASE.assassins[assassin].real_name
+                labels.append(
+                    Label(f"({e.identifier}) Enabled HTML for {name}'s report.")
+                )
+            if fix_ptr == len(suggestion_ids):
+                break
+        return labels

--- a/AU2/plugins/sanity_checks/__init__.py
+++ b/AU2/plugins/sanity_checks/__init__.py
@@ -1,0 +1,8 @@
+from typing import Dict
+
+from AU2.plugins.sanity_checks.MissingHtmlSpecifier import MissingHtmlSpecifier
+from AU2.plugins.sanity_checks.model.SanityCheck import SanityCheck
+
+SANITY_CHECKS: Dict[str, SanityCheck] = {
+    "Missing_HTML_Specifiers": MissingHtmlSpecifier()
+}

--- a/AU2/plugins/sanity_checks/model/SanityCheck.py
+++ b/AU2/plugins/sanity_checks/model/SanityCheck.py
@@ -1,0 +1,68 @@
+import dataclasses
+from typing import List
+
+from AU2.database.model import Event
+from AU2.html_components import HTMLComponent
+
+
+@dataclasses.dataclass
+class Suggestion:
+    """
+    Dataclass to store information about sanity check changes
+    """
+
+    # Explanation of the change to be displayed to user.
+    # Keep this short.
+    explanation: str
+
+    # Identifier that uniquely identifies the change to the SanityCheck.
+    identifier: str
+
+
+class SanityCheck:
+    """
+    Represents a check that must be performed before pages generate.
+    """
+    identifier: str
+
+    def has_marked(self, e: Event) -> bool:
+        """
+        Returns True if e has been marked by this sanity check.
+        """
+        return self.identifier in e.pluginState.get("sanity_checks", [])
+
+    def mark(self, e: Event):
+        """
+        Marks an event as having been reviewed by this SanityCheck.
+        Marked events are not reviewed in subsequent iterations.
+
+        Arguments:
+            e: Event to mark
+        """
+        e.pluginState.setdefault("sanity_checks", []).append(self.identifier)
+
+    def suggest_event_fixes(self, e: Event) -> List[Suggestion]:
+        """
+        Returns a list of suggestions for fixes to an event.
+
+        Arguments:
+            e: Event to suggest changes for
+
+        Returns:
+            List of suggestions
+        """
+        raise NotImplementedError()
+
+    def fix_event(self, e: Event, suggestion_ids: List[str]) -> List[HTMLComponent]:
+        """
+        After a user has confirmed one or more changes are wanted, this function
+        executes the changes
+
+        Arguments:
+            e: Event to fix
+            suggestion_ids: List of suggestion identifiers that should be implemented
+
+        Returns:
+            List of HTML components to display to user.
+        """
+        raise NotImplementedError()

--- a/AU2/plugins/util/game.py
+++ b/AU2/plugins/util/game.py
@@ -6,6 +6,9 @@ from AU2.database.GenericStateDatabase import GENERIC_STATE_DATABASE
 from AU2.plugins.util.date_utils import get_now_dt
 
 
+HTML_REPORT_PREFIX = "<!--HTML-->"
+
+
 def get_game_start() -> datetime.datetime:
     """
     Returns the start of the game.
@@ -26,14 +29,14 @@ def set_game_start(date: datetime.datetime):
 
 def soft_escape(string: str) -> str:
     """
-    Escapes only if not prefixed by <!--HTML-->
+    Escapes only if not prefixed by HTML_REPORT_PREFIX
     """
 
     # umpires may regret allowing this
     # supposing you are a clever player who has found this and the umpire does not know...
     # please spare the umpire any headaches
     # and remember that code injection without explicit consent is illegal (CMA sxn 2/3)
-    if not string.startswith("<!--HTML-->"):
+    if not string.startswith(HTML_REPORT_PREFIX):
         return escape(string)
     return string
 


### PR DESCRIPTION
Implements #80 

**Problem**: There are some usability issues with AU2 - to name a few, umpires occasionally mistype [P38] as [38] or forget to put `<!--HTML-->` in front of an HTML report. There's not a good error-checking facility in the tool to pick up on these unavoidable occasional mistakes, leading to these bleeding into production webpages.

**Solution**: I've implemented an extensible sanity checking framework - only requiring two functions to be implemented per sanity check. I've implemented one check for now as a proof of concept - hopefully we can work together to add more in future.

This was not trivial to do, because we really need the following requirements:
- Must not introduce more exports (an error-checking facility you can forget to click isn't useful)
- Must not be its own plugin (an error-checking facility you can forget to turn on isn't useful)
- Must run when you generate a page (this is a key point where errors become visible to players)
- Must be HTML-compatible (in case we ever make this front-end - so no dictionaries, tuples, etc.)
- Must clean up all reports BEFORE any pages generate (so must have special hoist status to the top of `answer_generate_pages`). Currently, execution order is undefined (NASAL DEMONS!)

With these in mind, why I did it how I did it hopefully makes sense. 