### PR TITLE
[82] Add encoding info (utf-8) to email headers

### DIFF
--- a/AU2/plugins/custom_plugins/SRCFPlugin.py
+++ b/AU2/plugins/custom_plugins/SRCFPlugin.py
@@ -51,6 +51,7 @@ EMAIL_TEMPLATE = """\
 MAIL FROM:assassins-umpire@srcf.net
 RCPT TO:{EMAIL}
 DATA
+Content-Type: text/plain; charset=UTF-8
 From: assassins-umpire@srcf.net
 Subject: {SUBJECT}
 {CONTENT}


### PR DESCRIPTION
Fixes #82 by adding `Content-Type: text/plain; charset=UTF-8` to email headers.

I have tested this works by sending an email to @NerdyNinja11 after making this change.