### PR TITLE
Remove `colorama` warning

### DIFF
--- a/AU2/frontends/inquirer_cli.py
+++ b/AU2/frontends/inquirer_cli.py
@@ -737,7 +737,7 @@ def main():
     try:
         from colorama import just_fix_windows_console
         just_fix_windows_console()
-    except Exception:
+    except:
         pass
 
     while True:

--- a/AU2/frontends/inquirer_cli.py
+++ b/AU2/frontends/inquirer_cli.py
@@ -732,15 +732,13 @@ def replace_overrides(component_list: List[HTMLComponent], existing_overrides={}
 
 
 def main():
-    # allow ANSI codes to work on old Windows terminals
-    # but don't let not having the module break the program!
+    # this fixes rendering of ANSI codes in old Windows terminals
+    # if it fails we don't want it to cause a crash though
     try:
         from colorama import just_fix_windows_console
         just_fix_windows_console()
-    except ModuleNotFoundError:
-        if os.name == "nt":
-            print("[WARNING] `colorama` is not installed; if you are using an old terminal, "
-                  "colours may not render correctly.")
+    except Exception:
+        pass
 
     while True:
         core_plugin: CorePlugin = PLUGINS["CorePlugin"]


### PR DESCRIPTION
As it is unnecessary now that colouring is not the only safeguard against accessing DangerousConfigExports after game start.