### PR TITLE
[73] Stats Page

### DIFF
--- a/AU2/__init__.py
+++ b/AU2/__init__.py
@@ -1,15 +1,14 @@
 import os
+import pathlib
 
 import pytz
 
-ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
+ROOT_DIR = pathlib.Path(os.path.abspath(__file__)).parent
 BASE_WRITE_LOCATION = os.path.expanduser("~/database")
 TIMEZONE = pytz.timezone("Europe/London")
 
 # Sets the encoding to utf-8 for pyinquirer on Windows machines, since that isn't the default for some reason
 if os.name == "nt":
-    import pathlib
-
     pathlib_open = pathlib.Path.open
     def pathlib_open_utf8(*args, **kwargs):
         # 'b' means to open a file in 'byte' mode, so we can't use an encoding in this case

--- a/AU2/database/model/Assassin.py
+++ b/AU2/database/model/Assassin.py
@@ -203,4 +203,4 @@ class Assassin(PersistentFile):
                 yield p
 
     def all_pseudonyms(self) -> str:
-        return " AKA ".join(self.pseudonyms)
+        return " AKA ".join(p for p in self.pseudonyms if p)

--- a/AU2/frontends/inquirer_cli.py
+++ b/AU2/frontends/inquirer_cli.py
@@ -44,10 +44,8 @@ from AU2.html_components.SpecialComponents.EditablePseudonymList import Editable
 from AU2.html_components.SpecialComponents.ConfigOptionsList import ConfigOptionsList
 from AU2.plugins.AbstractPlugin import Export, DangerousConfigExport
 from AU2.plugins.CorePlugin import PLUGINS, CorePlugin
-from AU2.plugins.util.date_utils import get_now_dt
+from AU2.plugins.util.date_utils import get_now_dt, DATETIME_FORMAT
 from AU2.plugins.util.game import escape_format_braces
-
-DATETIME_FORMAT = "%Y-%m-%d %H:%M"
 
 
 def datetime_validator(_, current):

--- a/AU2/plugins/custom_plugins/CompetencyPlugin.py
+++ b/AU2/plugins/custom_plugins/CompetencyPlugin.py
@@ -26,7 +26,7 @@ from AU2.plugins.custom_plugins.SRCFPlugin import Email
 from AU2.plugins.util.CompetencyManager import ID_GAME_START, ID_DEFAULT_EXTN, DEFAULT_START_COMPETENCY, \
     DEFAULT_EXTENSION, CompetencyManager
 from AU2.plugins.util.DeathManager import DeathManager
-from AU2.plugins.util.date_utils import get_now_dt
+from AU2.plugins.util.date_utils import get_now_dt, DATETIME_FORMAT
 from AU2.plugins.util.game import get_game_start
 
 INCOS_TABLE_TEMPLATE = """
@@ -416,8 +416,6 @@ class CompetencyPlugin(AbstractPlugin):
         for e in events:
             competency_manager.add_event(e)
             death_manager.add_event(e)
-
-        DATETIME_FORMAT = "%Y-%m-%d %H:%M"
 
         now = get_now_dt()
         deadlines = []

--- a/AU2/plugins/custom_plugins/html_templates/stats.html
+++ b/AU2/plugins/custom_plugins/html_templates/stats.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<link rel="preconnect" href="https://fonts.googleapis.com">
+	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+	<link href="https://fonts.googleapis.com/css2?family=Aref+Ruqaa+Ink:wght@700&family=Roboto+Slab&display=swap" rel="stylesheet">
+	<link rel="stylesheet" type="text/css" href="newassassins.css">
+ 	<link rel="shortcut icon" href="img/cloak3.png">
+	<script src="main.js"></script>
+ 	<title>The Assassins' Guild</title>
+</head>
+<body>
+<div class="backgroundimg">
+<div class="wrapper">
+
+	<div w3-include-html="header.html"></div>
+
+
+	<!--Main Content-->   <h2>End-of-Game Stats</h2>
+
+	{KILLTREE_LINK}
+
+	<p>Conkers score is calculated as the sum of the conkers scores of the people you killed plus the number of kills you made.</p>
+
+    {TABLE}
+
+<!--Footer-->
+	<div class="footer">
+		<h5>Assassins' Guild {YEAR}</h5>
+	</div>
+</div>
+</div>
+
+<script>
+	includeHTML();
+</script>
+</body></html>

--- a/AU2/plugins/util/date_utils.py
+++ b/AU2/plugins/util/date_utils.py
@@ -3,9 +3,12 @@ from typing import Optional
 
 from AU2 import TIMEZONE
 
+DATETIME_FORMAT = "%Y-%m-%d %H:%M"
+
 
 def get_now_dt():
    return datetime.datetime.now().astimezone(TIMEZONE)
+
 
 # global datetime <-> timestamp conversion functions to ensure consistency
 # supports "optional datetimes" comnverting `None` to `None`
@@ -13,6 +16,7 @@ def timestamp_to_dt(ts: Optional[float]) -> Optional[datetime.datetime]:
    if ts is None:
       return None
    return datetime.datetime.fromtimestamp(ts).astimezone().astimezone(TIMEZONE)
+
 
 def dt_to_timestamp(ts: Optional[datetime.datetime]) -> Optional[float]:
    if ts is None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,6 @@ inquirer
 datetime
 paramiko
 tabulate
-colorama # optional -- only needed if using an old Windows terminal
+colorama  # optional -- only needed if using an old Windows terminal
+pyvis  # optional -- only needed when generating graph visualisations
+lxml  # optional -- only needed when generating a kill-graph visualisation


### PR DESCRIPTION
This PR adds an export `Scoring -> Generate stats page` to `ScoringPlugin`.
The stats page is configurable, allowing the user to select which columns should be included. In addition to the standard columns
- Real Name
- Pseudonym
- Number of Kills
- Conkers Score

there is the option to include
- Number of Attempts
- Score (as calculated for Open Season)
- Died at (which includes a link to the relevant event)
- Position (which is just where the player appears in the ordering used on the stats page)

The user can choose between two ordering options: by number of kills (the way recent stats pages have been ordered), or based on order of death (the way stats pages were ordered previously).

Furthermore there is an option to generate a visualisation of the kill graph using `pyvis`. This is generated as a separate page which is linked to from the stats page.

There's still a bunch of scope for more game stats as @NerdyNinja11 has suggested, but this is sufficient for mimicking the stats pages of previous games at least.