### PR TITLE
[74] Allow frequently-used Exports to be pinned for ease of use

### DIFF
--- a/AU2/frontends/inquirer_cli.py
+++ b/AU2/frontends/inquirer_cli.py
@@ -4,7 +4,7 @@ import datetime
 import os
 import random
 import tabulate
-from typing import List, Any, Dict, Optional
+from typing import List, Any, Dict, Optional, Tuple
 
 import inquirer
 
@@ -743,18 +743,18 @@ def main():
     while True:
         core_plugin: CorePlugin = PLUGINS["CorePlugin"]
         exports = core_plugin.get_all_exports()
-
+        exit_option: List[Tuple[str, Optional[Export]]] = [("Exit", None)]
         q = [inquirer.List(name="mode", message="Select mode",
-                           choices=["Exit"] + [(e.display_name, e) for e in exports])]
+                           choices=exit_option + [(e.display_name, e) for e in exports])]
         try:
-            a = inquirer_prompt_with_abort(q)["mode"]
+            exp: Optional[Export] = inquirer_prompt_with_abort(q)["mode"]
         except KeyboardInterrupt:
-            a = "Exit"
-        if a == "Exit":
+            exp = None
+        if exp is None:
             print("Have a good day!")
             exit()
 
-        exp: Export = a
+        exp: Export
 
         params = []
         kwargs = {}

--- a/AU2/frontends/inquirer_cli.py
+++ b/AU2/frontends/inquirer_cli.py
@@ -745,7 +745,7 @@ def main():
         exports = core_plugin.get_all_exports()
 
         q = [inquirer.List(name="mode", message="Select mode",
-                           choices=["Exit"] + sorted([e.display_name for e in exports]))]
+                           choices=["Exit"] + [(e.display_name, e) for e in exports])]
         try:
             a = inquirer_prompt_with_abort(q)["mode"]
         except KeyboardInterrupt:
@@ -754,11 +754,7 @@ def main():
             print("Have a good day!")
             exit()
 
-        exp: Export = None
-        for e in exports:
-            if e.display_name == a:
-                exp = e
-                break
+        exp: Export = a
 
         params = []
         kwargs = {}

--- a/AU2/frontends/inquirer_cli.py
+++ b/AU2/frontends/inquirer_cli.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import copy
 import datetime
-import os
+import itertools
 import random
 import tabulate
 from typing import List, Any, Dict, Optional, Tuple
@@ -743,14 +743,15 @@ def main():
     while True:
         core_plugin: CorePlugin = PLUGINS["CorePlugin"]
         exports = core_plugin.get_all_exports()
-        exit_option: List[Tuple[str, Optional[Export]]] = [("Exit", None)]
+        exit_val = None
+        exit_option: List[Tuple[str, Optional[Export]]] = [("Exit", exit_val)]
         q = [inquirer.List(name="mode", message="Select mode",
                            choices=exit_option + [(e.display_name, e) for e in exports])]
         try:
             exp: Optional[Export] = inquirer_prompt_with_abort(q)["mode"]
         except KeyboardInterrupt:
-            exp = None
-        if exp is None:
+            exp = exit_val
+        if exp == exit_val:
             print("Have a good day!")
             exit()
 

--- a/AU2/frontends/inquirer_cli.py
+++ b/AU2/frontends/inquirer_cli.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import copy
 import datetime
-import itertools
 import random
 import tabulate
 from typing import List, Any, Dict, Optional, Tuple

--- a/AU2/plugins/CorePlugin.py
+++ b/AU2/plugins/CorePlugin.py
@@ -28,7 +28,6 @@ from AU2.plugins.AvailablePlugins import __PluginMap
 from AU2.plugins.constants import COLLEGES, WATER_STATUSES
 from AU2.plugins.sanity_checks import SANITY_CHECKS
 from AU2.plugins.util.game import get_game_start, set_game_start
-from AU2.plugins.util.date_utils import get_now_dt
 
 
 AVAILABLE_PLUGINS = {}

--- a/AU2/plugins/CorePlugin.py
+++ b/AU2/plugins/CorePlugin.py
@@ -374,12 +374,14 @@ class CorePlugin(AbstractPlugin):
         new_suppressed_exports = set(htmlResponse[self.config_html_ids["Suppressed Exports"]])
         current_suppression = set(GENERIC_STATE_DATABASE.arb_state.get("CorePlugin", {}).get("suppressed_exports", []))
         # only update suppression for exports of loaded plugins
-        for exp_id in (exp.identifier for exp in self.get_all_exports(include_suppressed=True)):
+        for exp in self.get_all_exports(include_suppressed=True):
+            exp_id = exp.identifier
             if exp_id in new_suppressed_exports:
                 current_suppression.add(exp_id)
             else:
                 current_suppression.discard(exp_id)
 
+        # should be necessary since
         for exp_id in self.IRREMOVABLE_EXPORTS:
             current_suppression.discard(exp_id)
 


### PR DESCRIPTION
**Problem:** As described by @NerdyNinja11 in #74, now that we have more plugins and exports it can get unwieldy navigating through the menu. We do already have a feature to hide certain menu items, but for functionality that is used occasionally it is cumbersome to have to un-suppress an export to use it and then re-suppress it afterwards; it would be much more useful to be able to keep most of the exports visible on the main menu but put the most frequently used ones at the top.

**Solution:** I have implemented a simple "pinning" system for exports: the ConfigExport `CorePlugin -> Pin menu options` can be used to select exports to be "pinned". Pinned exports are listed before non-pinned exports in the main menu. (Within each category, exports are ordered by display name as before).
I believe this should be sufficient to improve usability, but the way I have implemented this is compatible with finer control over the order of exports: each export has a numerical 'priority' assigned to it in the `arb_state` of `CorePlugin`, which determines the ordering — with the current 'pinning' interface this simply takes a value of `0` (unpinned) or `1` (pinned).

I have also improved the interface for suppressing exports, so that display names of exports are displayed rather than the internal identifiers. Exports of disabled plugins also no longer appear in this interface even if they are currenty suppressed, but suppressed exports of disabled plugins will still remain suppressed.

**Testing:** Manual