### PR TITLE
Include pseudonym index in `EditablePseudonymList`

### DIFF
--- a/AU2/frontends/inquirer_cli.py
+++ b/AU2/frontends/inquirer_cli.py
@@ -521,7 +521,7 @@ def render(html_component, dependency_context={}):
             q = [inquirer.List(
                 name=html_component.identifier,
                 message=escape_format_braces(html_component.title),
-                choices=[("*CONTINUE*", -1)] + [(v.text, i) for i, v in enumerate(values) if v.text] + [("*NEW*", -2)],
+                choices=[("*CONTINUE*", -1)] + [(f"{i}: {v.text}", i) for i, v in enumerate(values) if v.text] + [("*NEW*", -2)],
             )]
             a = inquirer_prompt_with_abort(q)
             c = a[html_component.identifier]  # index of choice


### PR DESCRIPTION
**Problem:** It is possible for umpires to specify which pseudonym should by rendered in a report using the [PX_i] format. However, the index *i* may differ from its position in the list of pseudonyms shown by `Assassin -> Update`. This is because pseudonyms keep their indices even when a pseudonym with a lower index is deleted.

**Solution:** Show the index of each pseudonym in the pseudonym editing interface `EditablePseudonymList`.

**Alternative idea:** Don't hide blank pseudonyms in `EditablePseudonymList` (but still treat blank pseudonyms as deleted when rendering pages).