### PR TITLE
Don't include hidden police on police page

### DIFF
--- a/AU2/plugins/custom_plugins/PolicePlugin.py
+++ b/AU2/plugins/custom_plugins/PolicePlugin.py
@@ -298,7 +298,8 @@ class PolicePlugin(AbstractPlugin):
 
         message += police_rank_manager.generate_new_ranks_if_necessary()
 
-        police: List[Assassin] = [a for a in ASSASSINS_DATABASE.assassins.values() if a.is_police]
+        # note: police who are hidden using `Assassin -> Hide` will not be included
+        police: List[Assassin] = ASSASSINS_DATABASE.get_filtered(include=lambda a: a.is_police)
         dead_police: List[Assassin] = [i for i in police if i.identifier in death_manager.get_dead()]
         alive_police: List[Assassin] = [i for i in police if i not in dead_police]
 


### PR DESCRIPTION
Currently, police hidden using `Assassin -> Hide` are still listed on the police page.

This is not intuitive behaviour, and there are usecases for wanting to hide police (e.g., if the umpire wants to use a "dummy" player to represent a civilian, then such a player would currently appear on the police page even if set to hidden. In the previous game (Mich 2024), the umpires created a non-police dummy assassin, which would have been catastrophic for targeting if it hadn't been open season).

This PR stops hidden police from being included on the police page.