### PR TITLE
[116] Prevent creation of non-Police assassins after first email

### DIFF
--- a/AU2/frontends/inquirer_cli.py
+++ b/AU2/frontends/inquirer_cli.py
@@ -472,7 +472,7 @@ def render(html_component, dependency_context={}):
         return {}
 
     elif isinstance(html_component, Checkbox):
-        default = "Yes" if html_component.checked else "No"
+        default = html_component.checked and "Yes" or "No"
         choices = [default] if html_component.force_default else ["No", "Yes"]
         q = [
             inquirer.List(

--- a/AU2/frontends/inquirer_cli.py
+++ b/AU2/frontends/inquirer_cli.py
@@ -472,12 +472,14 @@ def render(html_component, dependency_context={}):
         return {}
 
     elif isinstance(html_component, Checkbox):
+        default = "Yes" if html_component.checked else "No"
+        choices = [default] if html_component.force_default else ["No", "Yes"]
         q = [
             inquirer.List(
                 name="q",
                 message=escape_format_braces(html_component.title),
-                choices=["No", "Yes"],
-                default="Yes" if html_component.checked else "No"
+                choices=choices,
+                default=default
             )]
         a = inquirer_prompt_with_abort(q)
         return {html_component.identifier: a["q"] == "Yes"}

--- a/AU2/html_components/SimpleComponents/Checkbox.py
+++ b/AU2/html_components/SimpleComponents/Checkbox.py
@@ -6,11 +6,12 @@ from AU2.html_components import HTMLComponent
 class Checkbox(HTMLComponent):
     name: str = "Checkbox"
 
-    def __init__(self, identifier: str, title: str, checked: bool=False):
+    def __init__(self, identifier: str, title: str, checked: bool=False, force_default: bool=False):
         self.title = title
         self.identifier = identifier
         self.uniqueStr = self.get_unique_str()
         self.checked = checked
+        self.force_default = force_default
         super().__init__()
 
     def _representation(self) -> str:

--- a/AU2/html_components/SimpleComponents/Checkbox.py
+++ b/AU2/html_components/SimpleComponents/Checkbox.py
@@ -6,7 +6,8 @@ from AU2.html_components import HTMLComponent
 class Checkbox(HTMLComponent):
     name: str = "Checkbox"
 
-    def __init__(self, identifier: str, title: str, checked: bool=False, force_default: bool=False):
+    def __init__(self, identifier: str, title: str, checked: bool=False, *, force_default: bool=False):
+
         self.title = title
         self.identifier = identifier
         self.uniqueStr = self.get_unique_str()

--- a/AU2/plugins/CorePlugin.py
+++ b/AU2/plugins/CorePlugin.py
@@ -27,7 +27,7 @@ from AU2.plugins.AbstractPlugin import AbstractPlugin, Export, ConfigExport, Hoo
 from AU2.plugins.AvailablePlugins import __PluginMap
 from AU2.plugins.constants import COLLEGES, WATER_STATUSES
 from AU2.plugins.sanity_checks import SANITY_CHECKS
-from AU2.plugins.util.game import get_game_start, set_game_start
+from AU2.plugins.util.game import get_game_start, set_game_start, get_now_dt
 
 
 AVAILABLE_PLUGINS = {}
@@ -195,7 +195,17 @@ class CorePlugin(AbstractPlugin):
         ]
 
     def on_assassin_request_create(self):
+        # use this to detect whether the game has started or not, since sending the first email is the point when
+        # targets are "locked in" and adding new non-police players becomes dangerous
+        last_emailed_event = int(
+            GENERIC_STATE_DATABASE.arb_state.get("TargetingPlugin", {}).get("last_emailed_event", -1)
+        )
+
         html = [
+            *(
+                [Checkbox(self.html_ids["Police"], "Police? (y/n)")] if last_emailed_event == -1
+                else [Label("Assassin type: Police"), HiddenTextbox(self.html_ids["Police"], default=True)]
+            ),
             NamedSmallTextbox(self.html_ids["Pseudonym"], "Initial Pseudonym"),
             NamedSmallTextbox(self.html_ids["Real Name"], "Real Name"),
             NamedSmallTextbox(self.html_ids["Pronouns"], "Pronouns"),
@@ -204,7 +214,6 @@ class CorePlugin(AbstractPlugin):
             InputWithDropDown(self.html_ids["Water Status"], "Water Status", WATER_STATUSES),
             InputWithDropDown(self.html_ids["College"], "College", COLLEGES),
             LargeTextEntry(self.html_ids["Notes"], "Notes"),
-            Checkbox(self.html_ids["Police"], "Police? (y/n)")
         ]
         return html
 
@@ -212,9 +221,18 @@ class CorePlugin(AbstractPlugin):
         return [Label("[CORE] Success!")]
 
     def on_assassin_request_update(self, assassin: Assassin):
+        # use this to detect whether the game has started or not, since sending the first email is the point when
+        # targets are "locked in" and changing player types becomes dangerous.
+        last_emailed_event = int(
+            GENERIC_STATE_DATABASE.arb_state.get("TargetingPlugin", {}).get("last_emailed_event", -1)
+        )
+
         html = [
             HiddenTextbox(self.HTML_SECRET_ID, assassin.identifier),
-            Label("Assassin type: " + ("Police" if assassin.is_police else "Full Player")),
+            (
+                Checkbox(self.html_ids["Police"], "Police? (y/n)") if last_emailed_event == -1
+                else Label("Assassin type: " + ("Police" if assassin.is_police else "Full Player"))
+            ),
             EditablePseudonymList(
                 self.html_ids["Pseudonym"], "Edit Pseudonyms",
                 (PseudonymData(p, assassin.get_pseudonym_validity(i)) for i, p in enumerate(assassin.pseudonyms))
@@ -225,7 +243,7 @@ class CorePlugin(AbstractPlugin):
             DefaultNamedSmallTextbox(self.html_ids["Address"], "Address", assassin.address),
             InputWithDropDown(self.html_ids["Water Status"], "Water Status", WATER_STATUSES, selected=assassin.water_status),
             InputWithDropDown(self.html_ids["College"], "College", COLLEGES, selected=assassin.college),
-            LargeTextEntry(self.html_ids["Notes"], "Notes", default=assassin.notes),
+            LargeTextEntry(self.html_ids["Notes"], "Notes", default=assassin.notes)
         ]
         return html
 
@@ -243,6 +261,8 @@ class CorePlugin(AbstractPlugin):
         assassin.water_status = htmlResponse[self.html_ids["Water Status"]]
         assassin.college = htmlResponse[self.html_ids["College"]]
         assassin.notes = htmlResponse[self.html_ids["Notes"]]
+        if self.html_ids["Police"] in htmlResponse:
+            assassin.is_police = htmlResponse[self.html_ids["Police"]]
         return [Label("[CORE] Success!")]
 
     def on_event_request_create(self):

--- a/AU2/plugins/CorePlugin.py
+++ b/AU2/plugins/CorePlugin.py
@@ -27,7 +27,8 @@ from AU2.plugins.AbstractPlugin import AbstractPlugin, Export, ConfigExport, Hoo
 from AU2.plugins.AvailablePlugins import __PluginMap
 from AU2.plugins.constants import COLLEGES, WATER_STATUSES
 from AU2.plugins.sanity_checks import SANITY_CHECKS
-from AU2.plugins.util.game import get_game_start, set_game_start, get_now_dt
+from AU2.plugins.util.game import get_game_start, get_now_dt, set_game_start
+
 
 
 AVAILABLE_PLUGINS = {}
@@ -258,8 +259,7 @@ class CorePlugin(AbstractPlugin):
         assassin.water_status = htmlResponse[self.html_ids["Water Status"]]
         assassin.college = htmlResponse[self.html_ids["College"]]
         assassin.notes = htmlResponse[self.html_ids["Notes"]]
-        if self.html_ids["Police"] in htmlResponse:
-            assassin.is_police = htmlResponse[self.html_ids["Police"]]
+        assassin.is_police = htmlResponse[self.html_ids["Police"]]
         return [Label("[CORE] Success!")]
 
     def on_event_request_create(self):

--- a/AU2/plugins/CorePlugin.py
+++ b/AU2/plugins/CorePlugin.py
@@ -243,7 +243,6 @@ class CorePlugin(AbstractPlugin):
         last_emailed_event = int(
             GENERIC_STATE_DATABASE.arb_state.get("TargetingPlugin", {}).get("last_emailed_event", -1)
         )
-        print(last_emailed_event)
         html = [
             HiddenTextbox(self.HTML_SECRET_ID, assassin.identifier),
             EditablePseudonymList(

--- a/AU2/plugins/CorePlugin.py
+++ b/AU2/plugins/CorePlugin.py
@@ -203,9 +203,6 @@ class CorePlugin(AbstractPlugin):
         )
 
         html = [
-            Checkbox(self.html_ids["Police"], "Police? (y/n)",
-                     checked=last_emailed_event != -1,
-                     force_default=last_emailed_event != -1),
             NamedSmallTextbox(self.html_ids["Pseudonym"], "Initial Pseudonym"),
             NamedSmallTextbox(self.html_ids["Real Name"], "Real Name"),
             NamedSmallTextbox(self.html_ids["Pronouns"], "Pronouns"),
@@ -214,6 +211,9 @@ class CorePlugin(AbstractPlugin):
             InputWithDropDown(self.html_ids["Water Status"], "Water Status", WATER_STATUSES),
             InputWithDropDown(self.html_ids["College"], "College", COLLEGES),
             LargeTextEntry(self.html_ids["Notes"], "Notes"),
+            Checkbox(self.html_ids["Police"], "Police? (y/n)",
+                     checked=last_emailed_event >= 0,
+                     force_default=last_emailed_event >= 0)
         ]
         return html
 
@@ -226,11 +226,9 @@ class CorePlugin(AbstractPlugin):
         last_emailed_event = int(
             GENERIC_STATE_DATABASE.arb_state.get("TargetingPlugin", {}).get("last_emailed_event", -1)
         )
-
+        print(last_emailed_event)
         html = [
             HiddenTextbox(self.HTML_SECRET_ID, assassin.identifier),
-            Checkbox(self.html_ids["Police"], "Police? (y/n)", checked=assassin.is_police,
-                     force_default=last_emailed_event != -1),
             EditablePseudonymList(
                 self.html_ids["Pseudonym"], "Edit Pseudonyms",
                 (PseudonymData(p, assassin.get_pseudonym_validity(i)) for i, p in enumerate(assassin.pseudonyms))
@@ -241,7 +239,10 @@ class CorePlugin(AbstractPlugin):
             DefaultNamedSmallTextbox(self.html_ids["Address"], "Address", assassin.address),
             InputWithDropDown(self.html_ids["Water Status"], "Water Status", WATER_STATUSES, selected=assassin.water_status),
             InputWithDropDown(self.html_ids["College"], "College", COLLEGES, selected=assassin.college),
-            LargeTextEntry(self.html_ids["Notes"], "Notes", default=assassin.notes)
+            LargeTextEntry(self.html_ids["Notes"], "Notes", default=assassin.notes),
+            Checkbox(self.html_ids["Police"], "Police? (y/n)",
+                     checked=assassin.is_police,
+                     force_default=last_emailed_event >= 0)
         ]
         return html
 

--- a/AU2/plugins/CorePlugin.py
+++ b/AU2/plugins/CorePlugin.py
@@ -202,10 +202,9 @@ class CorePlugin(AbstractPlugin):
         )
 
         html = [
-            *(
-                [Checkbox(self.html_ids["Police"], "Police? (y/n)")] if last_emailed_event == -1
-                else [Label("Assassin type: Police"), HiddenTextbox(self.html_ids["Police"], default=True)]
-            ),
+            Checkbox(self.html_ids["Police"], "Police? (y/n)",
+                     checked=last_emailed_event != -1,
+                     force_default=last_emailed_event != -1),
             NamedSmallTextbox(self.html_ids["Pseudonym"], "Initial Pseudonym"),
             NamedSmallTextbox(self.html_ids["Real Name"], "Real Name"),
             NamedSmallTextbox(self.html_ids["Pronouns"], "Pronouns"),
@@ -229,10 +228,8 @@ class CorePlugin(AbstractPlugin):
 
         html = [
             HiddenTextbox(self.HTML_SECRET_ID, assassin.identifier),
-            (
-                Checkbox(self.html_ids["Police"], "Police? (y/n)") if last_emailed_event == -1
-                else Label("Assassin type: " + ("Police" if assassin.is_police else "Full Player"))
-            ),
+            Checkbox(self.html_ids["Police"], "Police? (y/n)", checked=assassin.is_police,
+                     force_default=last_emailed_event != -1),
             EditablePseudonymList(
                 self.html_ids["Pseudonym"], "Edit Pseudonyms",
                 (PseudonymData(p, assassin.get_pseudonym_validity(i)) for i, p in enumerate(assassin.pseudonyms))


### PR DESCRIPTION
**Problem:** It is currently possible to create a non-Police assassin once a game has started, even though this messes up the targeting graph.

**Solution:** Initially I was going to use `get_game_start` for this, but I realised that this wouldn't work because it defaults to the current datetime so is not a reliable indicator that that game has actually started. So instead I use the `last_emailed_event` stored in the GenericStateDatabase by `TargetingPlugin` when emails are sent, to determine whether the game has started or not. This is actually precisely what we want, because the whole point here is stopping the targeting graph completely changing, which only matters once targets have been sent out!

**Testing:** Manual.