### PR TITLE
[122] Fixed list of corpses on inco list page

### DIFF
--- a/AU2/plugins/custom_plugins/CompetencyPlugin.py
+++ b/AU2/plugins/custom_plugins/CompetencyPlugin.py
@@ -456,11 +456,15 @@ class CompetencyPlugin(AbstractPlugin):
             competency_manager.add_event(e)
             death_manager.add_event(e)
 
-        # note: this includes hidden players
-        # which is important because otherwise dead incos would disappear when resurrected as police!
-        incos = competency_manager.get_incos_at(limit)
-        dead_incos: List[Assassin] = [i for i in incos if i.identifier in death_manager.get_dead()]
-        alive_incos: List[Assassin] = [i for i in incos if i not in dead_incos and not i.hidden]
+        # dead incos != incos who are currently dead,
+        # but rather players who died while inco.
+        # note that `dead_incos` includes hidden assassins,
+        # otherwise a player would disappear from the list of corpses when resurrected as police
+        dead_incos = competency_manager.inco_corpses
+        alive_incos: List[Assassin] = [i for i in competency_manager.get_incos_at(limit)
+                                       if not i.hidden
+                                       and competency_manager.is_inco_at(i, limit)
+                                       and not death_manager.is_dead(i)]
 
         tables = []
         if alive_incos:

--- a/AU2/plugins/custom_plugins/CompetencyPlugin.py
+++ b/AU2/plugins/custom_plugins/CompetencyPlugin.py
@@ -456,9 +456,11 @@ class CompetencyPlugin(AbstractPlugin):
             competency_manager.add_event(e)
             death_manager.add_event(e)
 
+        # note: this includes hidden players
+        # which is important because otherwise dead incos would disappear when resurrected as police!
         incos = competency_manager.get_incos_at(limit)
         dead_incos: List[Assassin] = [i for i in incos if i.identifier in death_manager.get_dead()]
-        alive_incos: List[Assassin] = [i for i in incos if i not in dead_incos]
+        alive_incos: List[Assassin] = [i for i in incos if i not in dead_incos and not i.hidden]
 
         tables = []
         if alive_incos:
@@ -478,8 +480,7 @@ class CompetencyPlugin(AbstractPlugin):
                 INCOS_TABLE_TEMPLATE.format(ROWS="".join(rows))
             )
 
-        # TODO: Disabled until logic for dead incos is repaired
-        if dead_incos and False:
+        if dead_incos:
             dead_incos.sort(key=lambda a: (a.college, a.real_name))
             rows = []
             for a in dead_incos:

--- a/AU2/plugins/util/CompetencyManager.py
+++ b/AU2/plugins/util/CompetencyManager.py
@@ -43,8 +43,6 @@ class CompetencyManager:
                 victim_model = ASSASSINS_DATABASE.get(victim)
                 if victim_model.is_police:
                     continue
-                if self.is_inco_at(victim_model, e.datetime):
-                    self.inco_corpses.append(victim)
                 self.attempts_since_kill[killer] = 0
                 # Allows overriding auto competency on a case-by-case basis
                 if killer in e.pluginState.get("CompetencyPlugin", {}).get("competency", {}):

--- a/AU2/plugins/util/CompetencyManager.py
+++ b/AU2/plugins/util/CompetencyManager.py
@@ -1,9 +1,8 @@
 import datetime
 
 from collections import defaultdict
-from typing import Optional
+from typing import Optional, List
 
-from AU2 import TIMEZONE
 from AU2.database.AssassinsDatabase import ASSASSINS_DATABASE
 from AU2.database.GenericStateDatabase import GENERIC_STATE_DATABASE
 from AU2.database.model import Event, Assassin
@@ -22,6 +21,7 @@ class CompetencyManager:
     def __init__(self, game_start: datetime.datetime):
         # from assassin ID to deadline
         self.deadlines = defaultdict(lambda: self.game_start + self.initial_competency_period)
+        self.inco_corpses: List[Assassin] = []
         self.game_start = game_start
         self.initial_competency_period = datetime.timedelta(days=GENERIC_STATE_DATABASE.arb_int_state.get(ID_GAME_START, DEFAULT_START_COMPETENCY))
         self.activated = GENERIC_STATE_DATABASE.plugin_map.get("CompetencyPlugin", False)
@@ -34,10 +34,17 @@ class CompetencyManager:
                 self.deadlines[aID],
                 e.datetime + datetime.timedelta(days=extn)
             )
+        for (_, victim) in e.kills:
+            victim_model = ASSASSINS_DATABASE.get(victim)
+            if self.is_inco_at(victim_model, e.datetime):
+                self.inco_corpses.append(victim_model)
         if self.auto_competency:
             for (killer, victim) in e.kills:
-                if ASSASSINS_DATABASE.get(victim).is_police:
+                victim_model = ASSASSINS_DATABASE.get(victim)
+                if victim_model.is_police:
                     continue
+                if self.is_inco_at(victim_model, e.datetime):
+                    self.inco_corpses.append(victim)
                 self.attempts_since_kill[killer] = 0
                 # Allows overriding auto competency on a case-by-case basis
                 if killer in e.pluginState.get("CompetencyPlugin", {}).get("competency", {}):

--- a/AU2/test/test_utils.py
+++ b/AU2/test/test_utils.py
@@ -106,6 +106,7 @@ class MockGame:
 
     def __init__(self):
         self.date = datetime.datetime(year=2022, month=9, day=1, hour=10, minute=0, second=0).astimezone(TIMEZONE)
+        self.game_start = self.date
         self.assassins = list()
         self.all_assassins = list()
 
@@ -124,9 +125,9 @@ class MockGame:
                 if victim_name in self.assassins:
                     self.assassins.remove(victim_name)
 
-    def new_datetime(self) -> datetime.datetime:
+    def new_datetime(self, minutes: int = 1) -> datetime.datetime:
         old_date = self.date
-        self.date = self.date + datetime.timedelta(minutes=1)
+        self.date = self.date + datetime.timedelta(minutes=minutes)
         return old_date
 
     def having_assassins(self, names: List[str]) -> "MockGame":


### PR DESCRIPTION
**Problem:** Currently, the "list of corpses" on the inco list page has been disabled. This is because of a logic error: the current code shows a list of *incos who are currently dead* rather than *players who died whilest inco*.

**Solution:** `CompetencyManager` now also tracks a list of corpses of players who died while inco. This only works correctly if events are added to the manager in chronological order (as `CompetencyPlugin` does).

**Testing:** Manual.
I created events both where a player died while inco and where a player died while not inco, then generated the page inco page for after the latter's inco deadline had passed. Only the former player was included in the list of corpses.