### PR TITLE
[115] Refactored stats page generation to use `Generate pages`

### DIFF
--- a/AU2/database/AssassinsDatabase.py
+++ b/AU2/database/AssassinsDatabase.py
@@ -2,7 +2,7 @@ import os
 
 from dataclasses import dataclass
 from dataclasses_json import dataclass_json
-from typing import Dict, List, Callable, Tuple, Optional
+from typing import Dict, List, Callable, Tuple, Union
 
 from AU2 import BASE_WRITE_LOCATION
 from AU2.database.model import PersistentFile, Assassin
@@ -46,29 +46,37 @@ class AssassinsDatabase(PersistentFile):
 
     def get_filtered(self, *,
                      include: Callable[[Assassin], bool] = lambda x: True,
-                     include_hidden: Callable[[Assassin], bool] = lambda x: False) -> List[Assassin]:
+                     include_hidden: Union[Callable[[Assassin], bool], bool] = False) -> List[Assassin]:
         """
         Parameters:
             include: function that takes a non-hidden assassin and returns whether it should be included in the
                 returned list. Defaults to always return True.
-            include_hidden: function that takes a hidden Assassin object and returns whether it should be include in the
-                returned list. Defaults to always return False.
+            include_hidden: either
+                - A boolean indicating whether hidden assassins should be returned (if True, the same criteria as for
+                    non-hidden assassins are applied for inclusion, if False, no hidden assassins are returned)
+                - Or a function that takes a hidden Assassin object and returns whether it should be include in the
+                returned list.
 
         Returns:
             list of non-hidden assassins (as Assassin objects) satisfying `include`, and hidden assassins satisfying
                 include_hidden
         """
+        if isinstance(include_hidden, bool):
+            include_hidden = include if include_hidden else lambda x: False
         return [a for a in self.assassins.values() if (a.hidden and include_hidden(a)) or (not a.hidden and include(a))]
 
     def get_identifiers(self, *,
-                     include: Callable[[Assassin], bool] = lambda x: True,
-                     include_hidden: Callable[[Assassin], bool] = lambda x: False) -> List[str]:
+                        include: Callable[[Assassin], bool] = lambda x: True,
+                        include_hidden: Union[Callable[[Assassin], bool], bool] = False) -> List[str]:
         """
         Parameters:
             include: function that takes a non-hidden assassin and returns whether it should be included in the
                 returned list. Defaults to always return True.
-            include_hidden: function that takes a hidden Assassin object and returns whether it should be include in the
-                returned list. Defaults to always return False.
+            include_hidden: either
+                - A boolean indicating whether hidden assassins should be returned (if True, the same criteria as for
+                    non-hidden assassins are applied for inclusion, if False, no hidden assassins are returned)
+                - Or a function that takes a hidden Assassin object and returns whether it should be include in the
+                returned list.
         Returns:
             list of identifiers sorted alphabetically, filtered according to the `include` and `include_hidden` functions
         """
@@ -77,13 +85,16 @@ class AssassinsDatabase(PersistentFile):
 
     def get_ident_pseudonym_pairs(self, *,
                      include: Callable[[Assassin], bool] = lambda x: True,
-                     include_hidden: Callable[[Assassin], bool] = lambda x: False) -> List[Tuple[str, List[str]]]:
+                     include_hidden: Union[Callable[[Assassin], bool], bool] = False) -> List[Tuple[str, List[str]]]:
         """
         Parameters:
             include: function that takes a non-hidden assassin and returns whether it should be included in the
                 returned list. Defaults to always return True.
-            include_hidden: function that takes a hidden Assassin object and returns whether it should be include in the
-                returned list. Defaults to always return False.
+            include_hidden: either
+                - A boolean indicating whether hidden assassins should be returned (if True, the same criteria as for
+                    non-hidden assassins are applied for inclusion, if False, no hidden assassins are returned)
+                - Or a function that takes a hidden Assassin object and returns whether it should be include in the
+                returned list.
         Returns:
             list of identifiers sorted alphabetically, filtered according to the `include` and `include_hidden` functions
         """

--- a/AU2/plugins/CorePlugin.py
+++ b/AU2/plugins/CorePlugin.py
@@ -29,6 +29,7 @@ from AU2.plugins.AvailablePlugins import __PluginMap
 from AU2.plugins.constants import COLLEGES, WATER_STATUSES
 from AU2.plugins.sanity_checks import SANITY_CHECKS
 from AU2.plugins.util.game import get_game_start, set_game_start, get_game_end, set_game_end
+from AU2.plugins.util.date_utils import get_now_dt
 
 
 AVAILABLE_PLUGINS = {}
@@ -184,7 +185,7 @@ class CorePlugin(AbstractPlugin):
             ConfigExport(
                 "core_plugin_set_game_end",
                 "CorePlugin -> Set game end",
-                self.ask_set_game_send,
+                self.ask_set_game_end,
                 self.answer_set_game_end
             ),
             ConfigExport(
@@ -729,11 +730,12 @@ class CorePlugin(AbstractPlugin):
         ]
 
     def ask_set_game_end(self) -> List[HTMLComponent]:
+        default = get_game_end()
         return [
             OptionalDatetimeEntry(
                 self.identifier + "_game_end",
                 title="Enter game end",
-                default=get_game_end()
+                default=get_now_dt() if default is None else default
             )
         ]
 

--- a/AU2/plugins/CorePlugin.py
+++ b/AU2/plugins/CorePlugin.py
@@ -13,6 +13,7 @@ from AU2.html_components.DependentComponents.AssassinDependentReportEntry import
 from AU2.html_components.DependentComponents.AssassinPseudonymPair import AssassinPseudonymPair
 from AU2.html_components.SimpleComponents.Checkbox import Checkbox
 from AU2.html_components.SimpleComponents.DatetimeEntry import DatetimeEntry
+from AU2.html_components.SimpleComponents.OptionalDatetimeEntry import OptionalDatetimeEntry
 from AU2.html_components.SimpleComponents.DefaultNamedSmallTextbox import DefaultNamedSmallTextbox
 from AU2.html_components.MetaComponents.Dependency import Dependency
 from AU2.html_components.SimpleComponents.HiddenTextbox import HiddenTextbox
@@ -27,7 +28,7 @@ from AU2.plugins.AbstractPlugin import AbstractPlugin, Export, ConfigExport, Hoo
 from AU2.plugins.AvailablePlugins import __PluginMap
 from AU2.plugins.constants import COLLEGES, WATER_STATUSES
 from AU2.plugins.sanity_checks import SANITY_CHECKS
-from AU2.plugins.util.game import get_game_start, set_game_start
+from AU2.plugins.util.game import get_game_start, set_game_start, get_game_end, set_game_end
 
 
 AVAILABLE_PLUGINS = {}
@@ -179,6 +180,12 @@ class CorePlugin(AbstractPlugin):
                 "CorePlugin -> Set game start",
                 self.ask_set_game_start,
                 self.answer_set_game_start
+            ),
+            ConfigExport(
+                "core_plugin_set_game_end",
+                "CorePlugin -> Set game end",
+                self.ask_set_game_send,
+                self.answer_set_game_end
             ),
             ConfigExport(
                 "core_plugin_suppress_exports",
@@ -706,7 +713,7 @@ class CorePlugin(AbstractPlugin):
 
         return config.answer(htmlResponse)
 
-    def ask_set_game_start(self):
+    def ask_set_game_start(self) -> List[HTMLComponent]:
         return [
             DatetimeEntry(
                 self.identifier + "_game_start",
@@ -715,8 +722,25 @@ class CorePlugin(AbstractPlugin):
             )
         ]
 
-    def answer_set_game_start(self, htmlResponse):
+    def answer_set_game_start(self, htmlResponse) -> List[HTMLComponent]:
         set_game_start(htmlResponse[self.identifier + "_game_start"])
         return [
             Label(f"[CORE] Set game start to {get_game_start().strftime('%Y-%m-%d %H:%M:%S')}")
+        ]
+
+    def ask_set_game_end(self) -> List[HTMLComponent]:
+        return [
+            OptionalDatetimeEntry(
+                self.identifier + "_game_end",
+                title="Enter game end",
+                default=get_game_end()
+            )
+        ]
+
+    def answer_set_game_end(self, htmlResponse) -> List[HTMLComponent]:
+        new_end = htmlResponse[self.identifier + "_game_end"]
+        set_game_end(new_end)
+        return [
+            Label(f"[CORE] Set game end to {new_end.strftime('%Y-%m-%d %H:%M:%S')}") if new_end
+            else Label(f"[CORE] Unset game end.")
         ]

--- a/AU2/plugins/custom_plugins/CompetencyPlugin.py
+++ b/AU2/plugins/custom_plugins/CompetencyPlugin.py
@@ -9,7 +9,6 @@ from AU2.database.GenericStateDatabase import GENERIC_STATE_DATABASE
 from AU2.database.model import Event, Assassin
 from AU2.html_components import HTMLComponent
 from AU2.html_components.DependentComponents.AssassinDependentIntegerEntry import AssassinDependentIntegerEntry
-from AU2.html_components.DependentComponents.AssassinDependentSelector import AssassinDependentSelector
 from AU2.html_components.SimpleComponents.DatetimeEntry import DatetimeEntry
 from AU2.html_components.MetaComponents.Dependency import Dependency
 from AU2.html_components.SimpleComponents.InputWithDropDown import InputWithDropDown
@@ -27,7 +26,7 @@ from AU2.plugins.util.CompetencyManager import ID_GAME_START, ID_DEFAULT_EXTN, D
     DEFAULT_EXTENSION, CompetencyManager
 from AU2.plugins.util.DeathManager import DeathManager
 from AU2.plugins.util.date_utils import get_now_dt, DATETIME_FORMAT
-from AU2.plugins.util.game import get_game_start
+from AU2.plugins.util.game import get_game_start, get_game_end
 
 INCOS_TABLE_TEMPLATE = """
 <p xmlns="">
@@ -392,9 +391,13 @@ class CompetencyPlugin(AbstractPlugin):
         return [Label("[COMPETENCY] Success!")]
 
     def on_page_request_generate(self) -> List[HTMLComponent]:
+        now = get_now_dt()
+        end = get_game_end()
+        default = now if (end is None or now < end) else end  # to preserve the inco list at the end of game
         return [DatetimeEntry(
             identifier=self.html_ids["Datetime"],
-            title="Enter date to calculate incos from"
+            title="Enter date to calculate incos from",
+            default=default
         )]
 
     def ask_show_inco_deadlines(self):

--- a/AU2/plugins/custom_plugins/ScoringPlugin.py
+++ b/AU2/plugins/custom_plugins/ScoringPlugin.py
@@ -441,10 +441,10 @@ Syntax:
                         key=lambda e: e.datetime)
         openseason_end = get_game_end() or get_now_dt()
         for e in events:
-            score_manager.add_event(e)
             # stops the duel changing the openseason page
             if e.datetime > openseason_end:
                 break
+            score_manager.add_event(e)
 
         table_str = "Something went wrong..."
         if score_manager.live_assassins:

--- a/AU2/plugins/custom_plugins/ScoringPlugin.py
+++ b/AU2/plugins/custom_plugins/ScoringPlugin.py
@@ -26,7 +26,7 @@ from AU2.plugins.util.CompetencyManager import CompetencyManager
 from AU2.plugins.util.WantedManager import WantedManager
 from AU2.plugins.util.DeathManager import DeathManager
 from AU2.plugins.util.date_utils import get_now_dt, timestamp_to_dt, dt_to_timestamp, DATETIME_FORMAT
-from AU2.plugins.util.game import get_game_start
+from AU2.plugins.util.game import get_game_start, get_game_end
 
 OPENSEASON_TABLE_TEMPLATE = """
 <table xmlns="" class="playerlist">
@@ -178,17 +178,18 @@ class ScoringPlugin(AbstractPlugin):
             "Assassin": self.identifier + "_assassin",
             "Stats Columns": self.identifier + "_stats_cols",
             "Visualise Kills?": self.identifier + "_visualise_kills",
-            "End": self.identifier + "_openseason_end",
-            "Stats Order": self.identifier + "_stats_order"
+            "Stats Order": self.identifier + "_stats_order",
+            "Generate Stats Page?": self.identifier + "_stats_page"
         }
 
         self.plugin_state = {
             "Start": {'id': self.identifier + "_openseason_start", 'default': None},
             "Formula": {'id': self.identifier + "_score_formula", 'default': ''},
-            "Stats Columns": {'id': self.identifier + "_stats_cols", 'default': list(STATS_COLUMN_TEMPLATES.keys())},
+            "Stats Columns": {'id': self.identifier + "_stats_cols", 'default': [
+                "Real Name", "Pseudonym", "Number of Kills", "Conkers Score"
+            ]},
             "Visualise Kills?": {'id': self.identifier + "_visualise_kills", 'default': True},
-            "End": {'id': self.identifier + "_openseason_end", 'default': None},
-            "Stats Order": {'id': self.identifier + "_stats_order", 'default': ''}
+            "Stats Order": {'id': self.identifier + "_stats_order", 'default': 'By Kills (London style)'}
         }
 
         self.assassin_plugin_state = {
@@ -203,12 +204,6 @@ class ScoringPlugin(AbstractPlugin):
                 self.answer_set_bonuses,
                 (self.gather_assassins_and_bonuses,)
             ),
-            Export(
-                "scoring_stats_page",
-                "Scoring -> Generate stats page",
-                self.ask_stats_page,
-                self.answer_stats_page,
-            )
         ]
 
         self.config_exports = [
@@ -223,7 +218,7 @@ class ScoringPlugin(AbstractPlugin):
                 "Scoring -> Set formula",
                 self.ask_set_formula,
                 self.answer_set_formula
-            ),
+            )
         ]
 
     # plugin state management is copied from PolicePlugin
@@ -278,40 +273,12 @@ class ScoringPlugin(AbstractPlugin):
         self.aps_set(ident, "Bonus", new_bonus)
         return [Label("[SCORING] Set bonus.")]
 
-    def ask_stats_page(self) -> List[HTMLComponent]:
+    def _generate_stats_page(self,
+                             columns: List[str],
+                             generate_killtree: bool,
+                             stats_order: str) -> List[HTMLComponent]:
         components = []
-        selected_cols: List[str] = self.gsdb_get("Stats Columns")
-        all_cols = list(STATS_COLUMN_TEMPLATES.keys())
-        components.append(SelectorList(identifier=self.html_ids["Stats Columns"],
-                                       title="Which columns should be included in the player stats table?",
-                                       options=all_cols,
-                                       defaults=selected_cols))
-        components.append(InputWithDropDown(identifier=self.html_ids["Stats Order"],
-                                            title="How should players be ordered on the stats page?",
-                                            options=STATS_ORDERING_KEYS.keys(),
-                                            selected=self.gsdb_get("Stats Order")))
-        generate_killtree: bool = self.gsdb_get("Visualise Kills?")
-        components.append(Checkbox(identifier=self.html_ids["Visualise Kills?"],
-                                   title="Generate visualisation of kill graph?",
-                                   checked=generate_killtree))
-        end: Optional[datetime.datetime] = timestamp_to_dt(self.gsdb_get("End"))
-        components.append(OptionalDatetimeEntry(identifier=self.html_ids["End"],
-                                                title="Enter when Open Season ended (this is used to determine which "
-                                                      "players were duellists)",
-                                                default=end))
-        return components
-
-    def answer_stats_page(self, htmlResponse) -> List[HTMLComponent]:
-        components = []
-        # this is silly but needed to fix a bug where columns end up in the wrong order
-        columns: List[str] = [c for c in STATS_COLUMN_TEMPLATES if c in htmlResponse[self.html_ids["Stats Columns"]]]
-        self.gsdb_set("Stats Columns", columns)  # it is convenient for the columns previously selected to be remembered
-        generate_killtree: bool = htmlResponse[self.html_ids["Visualise Kills?"]]
-        self.gsdb_set("Visualise Kills?", generate_killtree)
-        openseason_end: Optional[datetime.datetime] = htmlResponse[self.html_ids["End"]]
-        self.gsdb_set("End", dt_to_timestamp(openseason_end))
-        stats_order = htmlResponse[self.html_ids["Stats Order"]]
-        self.gsdb_set("Stats Order", stats_order)
+        openseason_end = get_game_end()
         # use a score manager to count kills, conkers, and attempts
         # don't need to set the formula because we aren't going to fetch scores
         full_players = ASSASSINS_DATABASE.get_filtered(include=lambda a: not a.is_police,
@@ -452,12 +419,11 @@ Syntax:
         except Exception:
             return False
 
-    def on_page_generate(self, _) -> List[HTMLComponent]:
+    def _generate_openseason_page(self):
         # don't generate open season page if open season hasn't started!
         open_season_start = timestamp_to_dt(self.gsdb_get("Start"))
-        if not open_season_start or open_season_start >= get_now_dt():
+        if open_season_start and open_season_start >= get_now_dt():
             return []
-
         # also don't generate if formula is invalid
         formula = self.gsdb_get("Formula")
         if not self.formula_is_valid(formula):
@@ -465,16 +431,20 @@ Syntax:
 
         # need to include hidden assassins so that resurrecting as police doesn't stop kills counting
         score_manager = ScoreManager(ASSASSINS_DATABASE.get_identifiers(include=lambda a: not a.is_police,
-                                                                        include_hidden=lambda a: not a.is_police),
+                                                                        include_hidden=True),
                                      formula=formula,
                                      bonuses={
                                          ident: self.aps_get(ident, "Bonus")
-                                         for ident in ASSASSINS_DATABASE.get_identifiers()
+                                         for ident in ASSASSINS_DATABASE.get_identifiers(include_hidden=True)
                                      })
         events = sorted(EVENTS_DATABASE.events.values(),
                         key=lambda e: e.datetime)
+        openseason_end = get_game_end() or get_now_dt()
         for e in events:
             score_manager.add_event(e)
+            # stops the duel changing the openseason page
+            if e.datetime > openseason_end:
+                break
 
         table_str = "Something went wrong..."
         if score_manager.live_assassins:
@@ -505,5 +475,47 @@ Syntax:
                 )
             )
 
-        return [Label("[SCORING] Success!")]
+        return [Label("[SCORING] Generated openseason page.")]
 
+    def _should_generate_stats_page(self) -> bool:
+        game_end = get_game_end()
+        return (game_end < get_now_dt()) if game_end else False
+
+    def on_page_request_generate(self) -> List[HTMLComponent]:
+        components = []
+        # stats page generation
+        if self._should_generate_stats_page():
+            selected_cols: List[str] = self.gsdb_get("Stats Columns")
+            all_cols = list(STATS_COLUMN_TEMPLATES.keys())
+            generate_killtree: bool = self.gsdb_get("Visualise Kills?")
+            components.extend([
+                SelectorList(identifier=self.html_ids["Stats Columns"],
+                                           title="Which columns should be included in the player stats table?",
+                                           options=all_cols,
+                                           defaults=selected_cols),
+                InputWithDropDown(identifier=self.html_ids["Stats Order"],
+                                                title="How should players be ordered on the stats page?",
+                                                options=list(STATS_ORDERING_KEYS.keys()),
+                                                selected=self.gsdb_get("Stats Order")),
+                Checkbox(identifier=self.html_ids["Visualise Kills?"],
+                                       title="Generate visualisation of kill graph?",
+                                       checked=generate_killtree),
+                HiddenTextbox(identifier=self.html_ids["Generate Stats Page?"], default="True")
+            ])
+        return components
+
+    def on_page_generate(self, htmlResponse) -> List[HTMLComponent]:
+        components = []
+        components.extend(self._generate_openseason_page())
+        if htmlResponse.get(self.html_ids["Generate Stats Page?"], "False") == "True":
+            # this is silly but needed to fix a bug where columns end up in the wrong order
+            columns: List[str] = [c for c in STATS_COLUMN_TEMPLATES if
+                                  c in htmlResponse[self.html_ids["Stats Columns"]]]
+            self.gsdb_set("Stats Columns", columns)
+            generate_killtree: bool = htmlResponse[self.html_ids["Visualise Kills?"]]
+            self.gsdb_set("Visualise Kills?", generate_killtree)
+            stats_order = htmlResponse[self.html_ids["Stats Order"]]
+            self.gsdb_set("Stats Order", stats_order)
+            components.extend(self._generate_stats_page(columns, generate_killtree, stats_order))
+
+        return components

--- a/AU2/plugins/util/ScoreManager.py
+++ b/AU2/plugins/util/ScoreManager.py
@@ -1,7 +1,7 @@
 import functools
 import datetime
 from collections import defaultdict
-from typing import Dict, List, Set, Optional
+from typing import Dict, List, Set, Optional, Iterable
 
 from AU2.database.model import Event, Assassin
 from AU2.plugins.util.date_utils import dt_to_timestamp, get_now_dt
@@ -10,7 +10,7 @@ from AU2.plugins.util.date_utils import dt_to_timestamp, get_now_dt
 
 class ScoreManager:
     def __init__(self,
-                 assassin_ids: List[str],
+                 assassin_ids: Iterable[str],
                  formula: str = "",
                  bonuses: Dict[str, int] = {},
                  perma_death=True,

--- a/AU2/plugins/util/game.py
+++ b/AU2/plugins/util/game.py
@@ -1,5 +1,6 @@
 import datetime
 from html import escape
+from typing import Optional
 
 from AU2 import TIMEZONE
 from AU2.database.GenericStateDatabase import GENERIC_STATE_DATABASE
@@ -25,6 +26,22 @@ def set_game_start(date: datetime.datetime):
     Sets the start of the game
     """
     GENERIC_STATE_DATABASE.arb_state["game_start"] = date.timestamp()
+
+
+def get_game_end() -> Optional[datetime.datetime]:
+    """
+    Returns the end of the game, or `None` if the end of the game hasn't been set.
+    """
+    ts = GENERIC_STATE_DATABASE.arb_state.get("game_end", None)
+    return datetime.datetime.fromtimestamp(ts).astimezone(TIMEZONE) if ts else None
+
+
+def set_game_end(date: Optional[datetime.datetime]):
+    """
+    Sets the end of the game
+    """
+    GENERIC_STATE_DATABASE.arb_state["game_end"] = date.timestamp() if date else None
+
 
 def soft_escape(string: str) -> str:
     """
@@ -56,5 +73,4 @@ def escape_format_braces(string: str) -> str:
         >>> escape_format_braces(":} :{")
         ":}} :{{"
     """
-    # need type check because, when escaping default values, `None` is sometimes passed to this function
     return string.replace("{", "{{").replace("}", "}}")


### PR DESCRIPTION
See #115.
For this I have introduced a core "game end" config setting, which triggers stats page generation. The idea is that this parameter would also allow AU2 to distinguish the duel from the rest of the game.
Moreover
- the AU1-style ordering on the stats page uses its value to keep duellists near the top of the ranking
- the open season page is 'frozen' at its end of game state (i.e. duellists will not be removed if they die in the duel)
- when generating pages, the date to calculate incos for defaults to the end of game when generating pages after the end of game
