### PR TITLE
[125] Player & event status exports

### DIFF
--- a/AU2/database/model/Event.py
+++ b/AU2/database/model/Event.py
@@ -4,7 +4,6 @@ import datetime as dt
 from dataclasses_json import dataclass_json, config
 from typing import Any, Dict, Tuple, List
 
-from AU2 import TIMEZONE
 from AU2.database.GenericStateDatabase import GENERIC_STATE_DATABASE
 from AU2.database.model import PersistentFile
 from AU2.plugins.util.date_utils import dt_to_timestamp, timestamp_to_dt

--- a/AU2/html_components/SimpleComponents/InputWithDropDown.py
+++ b/AU2/html_components/SimpleComponents/InputWithDropDown.py
@@ -1,4 +1,3 @@
-from html import escape
 from typing import List
 
 from AU2.html_components import HTMLComponent

--- a/AU2/html_components/SimpleComponents/Table.py
+++ b/AU2/html_components/SimpleComponents/Table.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from AU2.html_components import HTMLComponent
 
@@ -8,7 +8,7 @@ class Table(HTMLComponent):
     name = "Table"
     noInteraction: bool = True
 
-    def __init__(self, rows: List[List[str]], headings: List[str] = []):
+    def __init__(self, rows: List[Tuple[str, ...]], headings: Tuple[str, ...] = tuple()):
         self.identifier = "Table" # needed for compatibility but not strictly relevant
         self.rows = rows
         self.headings = headings

--- a/AU2/plugins/AbstractPlugin.py
+++ b/AU2/plugins/AbstractPlugin.py
@@ -185,19 +185,19 @@ class AbstractPlugin:
         """
         return []
 
-    def on_request_assassin_status(self) -> List[HTMLComponent]:
+    def on_request_assassin_summary(self) -> List[HTMLComponent]:
         return []
 
-    def on_request_event_status(self) -> List[HTMLComponent]:
+    def on_request_event_summary(self) -> List[HTMLComponent]:
         return []
 
-    def render_assassin_status(self, _: Assassin) -> List[AttributePairTableRow]:
+    def render_assassin_summary(self, _: Assassin) -> List[AttributePairTableRow]:
         """
         Display any information about an ASSASSIN that is managed by this plugin
         """
         return []
 
-    def render_event_status(self, _: Event) -> List[AttributePairTableRow]:
+    def render_event_summary(self, _: Event) -> List[AttributePairTableRow]:
         """
         Display any information about an EVENT that is managed by this plugin
         """

--- a/AU2/plugins/AbstractPlugin.py
+++ b/AU2/plugins/AbstractPlugin.py
@@ -2,6 +2,7 @@ from typing import List, Tuple, Union, Any, Callable
 
 from AU2.database.model import Event, Assassin
 from AU2.html_components import HTMLComponent
+from AU2.html_components.SimpleComponents.Label import Label
 
 
 class Export:
@@ -101,6 +102,8 @@ class HookedExport:
         self.call_first = call_order
 
 
+AttributePairTableRow = Tuple[str, str]
+
 class AbstractPlugin:
     def __init__(self, identifier: str):
         # unique identifier for the plugin
@@ -179,5 +182,23 @@ class AbstractPlugin:
         """
         Allows you to respond to hooks from other plugins.
         `data` can be anything the hooking function wants you to contribute to
+        """
+        return []
+
+    def on_request_assassin_status(self) -> List[HTMLComponent]:
+        return []
+
+    def on_request_event_status(self) -> List[HTMLComponent]:
+        return []
+
+    def render_assassin_status(self, _: Assassin) -> List[AttributePairTableRow]:
+        """
+        Display any information about an ASSASSIN that is managed by this plugin
+        """
+        return []
+
+    def render_event_status(self, _: Event) -> List[AttributePairTableRow]:
+        """
+        Display any information about an EVENT that is managed by this plugin
         """
         return []

--- a/AU2/plugins/CorePlugin.py
+++ b/AU2/plugins/CorePlugin.py
@@ -238,7 +238,8 @@ class CorePlugin(AbstractPlugin):
             ("ID", str(assassin._secret_id)),
             ("Type", f"{hidden} {player_type}"),
             ("Name", assassin.real_name),
-            *((f"Pseudonym {i+1}", p) for i, p in enumerate(assassin.pseudonyms) if p),
+            *((f"Pseudonym {i} [P{assassin._secret_id}_{i}]", p)
+                for i, p in enumerate(assassin.pseudonyms) if p),
             ("Pronouns", assassin.pronouns),
             ("Email", assassin.email),
             ("Address", assassin.address),

--- a/AU2/plugins/custom_plugins/CompetencyPlugin.py
+++ b/AU2/plugins/custom_plugins/CompetencyPlugin.py
@@ -136,12 +136,14 @@ def get_player_infos(from_date=get_now_dt()) -> Dict[str, PlayerInfo]:
         is_gigainco = a.identifier not in active_players
         is_inco = competency_manager.is_inco_at(a, from_date)
         is_dead = death_manager.is_dead(a)
+
+        # Ordering of the below is important - don't reorder!
         if a.is_police:
             status = PlayerStatus.POLICE
-        elif is_gigainco and not is_dead:
-            status = PlayerStatus.GIGAINCOMPETENT
-        elif is_inco and is_dead:
+        elif is_dead:
             status = PlayerStatus.DEAD
+        elif is_gigainco:
+            status = PlayerStatus.GIGAINCOMPETENT
         elif is_inco:
             status = PlayerStatus.INCOMPETENT
         infos[a.identifier] = PlayerInfo(

--- a/AU2/plugins/custom_plugins/TargetingPlugin.py
+++ b/AU2/plugins/custom_plugins/TargetingPlugin.py
@@ -5,13 +5,13 @@ from typing import Tuple, Dict, List, Set
 from AU2.database.AssassinsDatabase import ASSASSINS_DATABASE
 from AU2.database.EventsDatabase import EVENTS_DATABASE
 from AU2.database.GenericStateDatabase import GENERIC_STATE_DATABASE
-from AU2.database.model import Event
+from AU2.database.model import Event, Assassin
 from AU2.html_components import HTMLComponent
 from AU2.html_components.SimpleComponents.Checkbox import Checkbox
 from AU2.html_components.SimpleComponents.IntegerEntry import IntegerEntry
 from AU2.html_components.SimpleComponents.Label import Label
 from AU2.html_components.SimpleComponents.SelectorList import SelectorList
-from AU2.plugins.AbstractPlugin import AbstractPlugin, Export, DangerousConfigExport
+from AU2.plugins.AbstractPlugin import AbstractPlugin, Export, DangerousConfigExport, AttributePairTableRow
 from AU2.plugins.CorePlugin import registered_plugin
 from AU2.plugins.custom_plugins.SRCFPlugin import Email
 
@@ -48,14 +48,7 @@ class TargetingPlugin(AbstractPlugin):
 
     def __init__(self):
         super().__init__("TargetingPlugin")
-        self.exports = [
-            Export(
-                "targeting_print_targeting_graph",
-                "Targeting Graph -> Print",
-                lambda *args: [],
-                self.answer_show_targeting_graph
-            )
-        ]
+        self.exports = []
 
         self.config_exports = [
             DangerousConfigExport(
@@ -184,18 +177,20 @@ class TargetingPlugin(AbstractPlugin):
         answer = "won't" if use_seeds_for_updates_only else "will"
         return [Label(f"[TARGETING] We {answer} use seeds for the initial targeting graph.")]
 
-    def answer_show_targeting_graph(self, _):
-        response = []
-        graph = self.compute_targets(response)
-        for (attacker, targets) in graph.items():
-            response.append(Label(attacker))
-            response.append(Label(f"|________ {targets[0]}"))
-            response.append(Label(f"|________ {targets[1]}"))
-            response.append(Label(f"|________ {targets[2]}"))
-            response.append(Label(""))
+    def render_assassin_status(self, assassin: Assassin) -> List[AttributePairTableRow]:
+        graph = self.compute_targets([]) # we don't care about any issues that arise
+        response: List[AttributePairTableRow] = []
+        if assassin.identifier not in graph:
+            return []
+        for (i, target) in enumerate(graph[assassin.identifier]):
+            response.append((f"Target {i+1}", target))
 
-        if graph:
-            response.append(Label(f"Total alive players: {len(graph.keys())}"))
+        num_attackers = 0
+        for (attacker, targets) in graph.items():
+            if assassin.identifier in targets:
+                response.append((f"Attacker {num_attackers+1}", attacker))
+                num_attackers += 1
+
         return response
 
     @property

--- a/AU2/plugins/custom_plugins/TargetingPlugin.py
+++ b/AU2/plugins/custom_plugins/TargetingPlugin.py
@@ -177,7 +177,7 @@ class TargetingPlugin(AbstractPlugin):
         answer = "won't" if use_seeds_for_updates_only else "will"
         return [Label(f"[TARGETING] We {answer} use seeds for the initial targeting graph.")]
 
-    def render_assassin_status(self, assassin: Assassin) -> List[AttributePairTableRow]:
+    def render_assassin_summary(self, assassin: Assassin) -> List[AttributePairTableRow]:
         graph = self.compute_targets([]) # we don't care about any issues that arise
         response: List[AttributePairTableRow] = []
         if assassin.identifier not in graph:

--- a/AU2/plugins/custom_plugins/UIConfigPlugin.py
+++ b/AU2/plugins/custom_plugins/UIConfigPlugin.py
@@ -9,6 +9,7 @@ from AU2.html_components import HTMLComponent
 from AU2.html_components.DependentComponents.AssassinPseudonymPair import AssassinPseudonymPair
 from AU2.html_components.MetaComponents.ComponentOverride import ComponentOverride
 from AU2.html_components.MetaComponents.Searchable import Searchable
+from AU2.html_components.SimpleComponents.InputWithDropDown import InputWithDropDown
 from AU2.html_components.SimpleComponents.Label import Label
 from AU2.html_components.SimpleComponents.SelectorList import SelectorList
 from AU2.plugins.AbstractPlugin import AbstractPlugin, ConfigExport
@@ -17,16 +18,29 @@ from AU2.plugins.CorePlugin import registered_plugin
 
 class Call(Flag):
     NONE = 0
-    EVENT_CREATE = 1
-    EVENT_UPDATE = 2
-    EVENT_DELETE = 4
-    ASSASSIN_CREATE = 8
-    ASSASSIN_UPDATE = 16
+    EVENT_CREATE = 2 << 0
+    EVENT_UPDATE = 2 << 1
+    EVENT_DELETE = 2 << 2
+    ASSASSIN_CREATE = 2 << 3
+    ASSASSIN_UPDATE = 2 << 4
+    ASSASSIN_STATUS = 2 << 5
+
 
 EnabledFor = namedtuple("EnabledFor", ("call", "hooks"), defaults=(Call.NONE, tuple()))
 
+
 @dataclass
 class UIChange:
+    """
+    Represents a change in the UI to be applied across the tool.
+
+    name (str): Name of this change to show in the UI
+    replaces (str): Identifier of component to replace
+    component (str): Replacement component
+    enabled_for (EnabledFor): The calls/hooks for which this change should be enabled
+    replacement_effects: A function to allow the new component to steal options/info from the replaced component.
+                         First arg is old component, second is new component
+    """
     name: str
     replaces: str
     component: HTMLComponent
@@ -75,9 +89,17 @@ class UIConfigPlugin(AbstractPlugin):
         def filter_options(component, l):
             component.options = [o for o in component.options if o in l or o in component.defaults]
 
+        def filter_input_dropdown(component, l):
+            component.options = [o for o in component.options if o in l or o == component.selected]
+
         def steal_options(old_comp, new_comp):
             new_comp.component.options = old_comp.options
             new_comp.component.defaults = old_comp.defaults
+            new_comp.component.title = old_comp.title
+
+        def steal_input_dropdown_options(old_comp, new_comp):
+            new_comp.component.options = old_comp.options
+            new_comp.component.selected = old_comp.selected
             new_comp.component.title = old_comp.title
 
         self.ui_changes = [
@@ -94,7 +116,7 @@ class UIConfigPlugin(AbstractPlugin):
                     accessor=lambda component: sorted([a[0] for a in component.assassins]),
                     setter=filter_assassin_list
                 ),
-                enabled_for=EnabledFor(call=Call.EVENT_CREATE | Call.EVENT_UPDATE),
+                enabled_for=EnabledFor(call=Call.EVENT_CREATE | Call.EVENT_UPDATE, hooks=tuple()),
                 replacement_effects=steal_assassins
             ),
             UIChange(
@@ -110,8 +132,24 @@ class UIConfigPlugin(AbstractPlugin):
                     accessor=lambda component: sorted(component.options),
                     setter=filter_options
                 ),
-                enabled_for=EnabledFor(hooks=("CorePlugin_hide_assassins",)),
+                enabled_for=EnabledFor(call=Call.NONE, hooks=("CorePlugin_hide_assassins",)),
                 replacement_effects=steal_options
+            ),
+            UIChange(
+                name="Searchable Assassins (Status)",
+                replaces="CorePlugin_assassin",
+                component=Searchable(
+                    component=InputWithDropDown(
+                        identifier="CorePlugin_assassin",
+                        title="",
+                        options=[]
+                    ),
+                    title="Enter assassin names to search for",
+                    accessor=lambda component: sorted(component.options),
+                    setter=filter_input_dropdown
+                ),
+                enabled_for=EnabledFor(call=Call.ASSASSIN_STATUS, hooks=tuple()),
+                replacement_effects=steal_input_dropdown_options
             )
         ]
 
@@ -133,6 +171,9 @@ class UIConfigPlugin(AbstractPlugin):
     def get_overrides_for_call(self, call: Call):
         comps = [c.get_for_call(call) for c in self.ui_changes]
         return [c for c in comps if c]
+
+    def on_request_assassin_status(self) -> List[HTMLComponent]:
+        return self.get_overrides_for_call(Call.ASSASSIN_STATUS)
 
     def on_event_request_create(self) -> List[HTMLComponent]:
         return self.get_overrides_for_call(Call.EVENT_CREATE)

--- a/AU2/plugins/custom_plugins/UIConfigPlugin.py
+++ b/AU2/plugins/custom_plugins/UIConfigPlugin.py
@@ -136,7 +136,7 @@ class UIConfigPlugin(AbstractPlugin):
                 replacement_effects=steal_options
             ),
             UIChange(
-                name="Searchable Assassins (Status)",
+                name="Searchable Assassins (Summary)",
                 replaces="CorePlugin_assassin",
                 component=Searchable(
                     component=InputWithDropDown(
@@ -172,7 +172,7 @@ class UIConfigPlugin(AbstractPlugin):
         comps = [c.get_for_call(call) for c in self.ui_changes]
         return [c for c in comps if c]
 
-    def on_request_assassin_status(self) -> List[HTMLComponent]:
+    def on_request_assassin_summary(self) -> List[HTMLComponent]:
         return self.get_overrides_for_call(Call.ASSASSIN_STATUS)
 
     def on_event_request_create(self) -> List[HTMLComponent]:

--- a/AU2/plugins/custom_plugins/WantedPlugin.py
+++ b/AU2/plugins/custom_plugins/WantedPlugin.py
@@ -11,7 +11,7 @@ from AU2.html_components import HTMLComponent
 from AU2.html_components.DependentComponents.AssassinDependentCrimeEntry import AssassinDependentCrimeEntry
 from AU2.html_components.MetaComponents.Dependency import Dependency
 from AU2.html_components.SimpleComponents.Label import Label
-from AU2.plugins.AbstractPlugin import AbstractPlugin
+from AU2.plugins.AbstractPlugin import AbstractPlugin, AttributePairTableRow
 from AU2.plugins.CorePlugin import registered_plugin
 from AU2.plugins.constants import WEBPAGE_WRITE_LOCATION
 from AU2.plugins.util.PoliceRankManager import PoliceRankManager, AUTO_RANK_DEFAULT, POLICE_KILLS_RANKUP_DEFAULT, \
@@ -118,6 +118,20 @@ class WantedPlugin(AbstractPlugin):
         e.pluginState[self.identifier] = htmlResponse[self.event_html_ids["Wanted"]]
         return [Label("[WANTED] Success!")]
 
+    def render_event_status(self, event: Event) -> List[AttributePairTableRow]:
+        results = []
+        for playerID in event.pluginState[self.identifier]:
+            name = ASSASSINS_DATABASE.get(playerID).real_name.split(" ")
+            if len(name) > 0:
+                name = name[0]
+            else:
+                name = "<no name...?!>"
+            duration, crime, redemption = event.pluginState[self.identifier][playerID]
+            results.append((f"Wanted duration ({name})", str(duration) + " days"))
+            results.append((f"Wanted crime ({name})", crime))
+            results.append((f"Wanted redemption ({name})", redemption))
+        return results
+
     def on_page_generate(self, htmlResponse) -> List[HTMLComponent]:
         messages = []
         # sort by datetime to ensure we read events in chronological order
@@ -168,6 +182,7 @@ class WantedPlugin(AbstractPlugin):
             )
         if wanted_police:
             rows = []
+            # TODO: These look like they can be deleted? Pycharm identifies default_rank and ranks as unread vars
             if police_ranks_enabled:
                 default_rank = GENERIC_STATE_DATABASE.arb_state.get(
                     "PolicePlugin", {}).get("PolicePlugin_default_rank", DEFAULT_POLICE_RANK)
@@ -209,6 +224,7 @@ class WantedPlugin(AbstractPlugin):
             )
         if wanted_police_deaths:
             rows = []
+            # TODO: These look like they can be deleted? Pycharm identifies default_rank and ranks as unread vars
             if police_ranks_enabled:
                 default_rank = GENERIC_STATE_DATABASE.arb_state.get(
                     "PolicePlugin", {}).get("PolicePlugin_default_rank", DEFAULT_POLICE_RANK)

--- a/AU2/plugins/custom_plugins/WantedPlugin.py
+++ b/AU2/plugins/custom_plugins/WantedPlugin.py
@@ -120,7 +120,7 @@ class WantedPlugin(AbstractPlugin):
 
     def render_event_summary(self, event: Event) -> List[AttributePairTableRow]:
         results = []
-        for playerID in event.pluginState[self.identifier]:
+        for playerID in event.pluginState.get(self.identifier, ()):
             a = ASSASSINS_DATABASE.get(playerID)
             sec_id = a._sec_id
             name = a.real_name.split(" ")

--- a/AU2/plugins/custom_plugins/WantedPlugin.py
+++ b/AU2/plugins/custom_plugins/WantedPlugin.py
@@ -118,18 +118,20 @@ class WantedPlugin(AbstractPlugin):
         e.pluginState[self.identifier] = htmlResponse[self.event_html_ids["Wanted"]]
         return [Label("[WANTED] Success!")]
 
-    def render_event_status(self, event: Event) -> List[AttributePairTableRow]:
+    def render_event_summary(self, event: Event) -> List[AttributePairTableRow]:
         results = []
         for playerID in event.pluginState[self.identifier]:
-            name = ASSASSINS_DATABASE.get(playerID).real_name.split(" ")
+            a = ASSASSINS_DATABASE.get(playerID)
+            sec_id = a._sec_id
+            name = a.real_name.split(" ")
             if len(name) > 0:
                 name = name[0]
             else:
                 name = "<no name...?!>"
             duration, crime, redemption = event.pluginState[self.identifier][playerID]
-            results.append((f"Wanted duration ({name})", str(duration) + " days"))
-            results.append((f"Wanted crime ({name})", crime))
-            results.append((f"Wanted redemption ({name})", redemption))
+            results.append((f"Wanted duration ({name} {sec_id})", str(duration) + " days"))
+            results.append((f"Wanted crime ({name} {sec_id})", crime))
+            results.append((f"Wanted redemption ({name} {sec_id})", redemption))
         return results
 
     def on_page_generate(self, htmlResponse) -> List[HTMLComponent]:


### PR DESCRIPTION
Implements #125 

**Problem**: There's currently no easy way to see a quick snapshot of what happened in an event or a player (you need to go through the update tool, which is far from rapid).

**Solution**: Add some `CorePlugin` functionality to render events & assassins with help from subordinate plugins.

Comes with a tweak in the UIConfigPlugin to make assassins in the status area searchable :-) 

Threw this together in an hour or so... feel free to take a fine-toothed comb to it and be nitpicky.