### PR TITLE
May Week News page

### DIFF
--- a/AU2/plugins/custom_plugins/MayWeekUtilitiesPlugin.py
+++ b/AU2/plugins/custom_plugins/MayWeekUtilitiesPlugin.py
@@ -26,7 +26,6 @@ from AU2.plugins.CorePlugin import registered_plugin
 from AU2.plugins.constants import WEBPAGE_WRITE_LOCATION
 from AU2.plugins.util.date_utils import get_now_dt
 from AU2.plugins.util.render_utils import render_all_events, get_color
-from AU2.plugins.util.DeathManager import DeathManager
 
 
 HEX_COLS = [
@@ -717,19 +716,17 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
 
         # generate may week news page
         # (this is so that the news is on one page rather than split into weeks)
+
+        # colour players by crew and don't do police, or inco colouring
         def mw_color_fn(pseudonym: str, assassin_model: Assassin, e: Event, managers: Iterable) -> str:
-            """"""
-            # get info from managers
+            # get crew info from manager
             team = None
-            dead = False
             for manager in managers:
                 if isinstance(manager, self.TeamManager):
                     team = manager.member_to_team[assassin_model.identifier]
-                elif isinstance(manager, DeathManager):
-                    dead = manager.is_dead(assassin_model)
 
-            # render dead colour
-            if dead:
+            # render dead colour -- but only if died *in this event*
+            if any(victim_id == assassin_model.identifier for (_, victim_id) in e.kills):
                 return get_color(pseudonym, dead=True)
 
             # but otherwise use team colours

--- a/AU2/plugins/custom_plugins/MayWeekUtilitiesPlugin.py
+++ b/AU2/plugins/custom_plugins/MayWeekUtilitiesPlugin.py
@@ -37,11 +37,14 @@ HEX_COLS = [
     '#b7a020', '#637777', '#f28110'
 ]
 
-CREW_COLOR_TEMPLATE = 'bgcolor="{HEX}"'
-TEAM_ENTRY_TEMPLATE = "<td>{TEAM}</td>"
+CREW_COLOR_TEMPLATE = 'style="background-color:{HEX}"'
+TEAM_ENTRY_TEMPLATE = "<td {CREW_COLOR}>{TEAM}</td>"
 TEAM_HDR_TEMPLATE = "<th>{TEAM_STR}</th>"
 PLAYER_ROW_TEMPLATE = "<tr><td>{REAL_NAME}</td><td>{PLAYER_TYPE}</td><td>{ADDRESS}</td><td>{COLLEGE}</td><td>{WATER_STATUS}</td><td>{NOTES}</td></tr>"
-PSEUDONYM_ROW_TEMPLATE = "<tr {CREW_COLOR}><td>{PSEUDONYM}</td><td>{POINTS}</td><td>{MULTIPLIER}</td>{TEAM_ENTRY}</tr>"
+PSEUDONYM_ROW_TEMPLATE = "<tr><td {CREW_COLOR}>{PSEUDONYM}</td>" \
+                         "<td {CREW_COLOR}>{POINTS}</td>" \
+                         "<td {CREW_COLOR}>{MULTIPLIER}</td>" \
+                         "{TEAM_ENTRY}</tr>"
 
 MAYWEEK_PLAYERS_TEMPLATE_PATH = ROOT_DIR / "plugins" / "custom_plugins" / "html_templates" / "may_week_utils_players.html"
 with open(MAYWEEK_PLAYERS_TEMPLATE_PATH, "r", encoding="utf-8", errors="ignore") as F:
@@ -676,7 +679,7 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
             # PSEUDONYM_ROW_TEMPLATE = "<tr {CREW_COLOR}><td>{RANK}</td><td>{PSEUDONYM}</td><td>{POINTS}</td><td>{MULTIPLIER}</td></tr>{TEAM_ENTRY}"
             team_id = member_to_team[a_id]
             crew_color = (CREW_COLOR_TEMPLATE.format(HEX=team_to_hex_col[team_id]) if team_id is not None else "")
-            team_entry = (TEAM_ENTRY_TEMPLATE.format(TEAM=team_names[team_id]) if team_id is not None else "")
+            team_entry = (TEAM_ENTRY_TEMPLATE.format(TEAM=team_names[team_id], CREW_COLOR=crew_color) if team_id is not None else "")
             assassin = ASSASSINS_DATABASE.get(a_id)
             pseudonym_rows.append(
                 PSEUDONYM_ROW_TEMPLATE.format(

--- a/AU2/plugins/custom_plugins/MayWeekUtilitiesPlugin.py
+++ b/AU2/plugins/custom_plugins/MayWeekUtilitiesPlugin.py
@@ -456,7 +456,7 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
                     owners.add(gainer)
         return list(owners)
 
-    def get_multiplier_beneficiaries(self, multiplier_owners: Iterable[str], team_manager) -> List[str]:
+    def get_multiplier_beneficiaries(self, multiplier_owners: List[str], team_manager) -> List[str]:
         teams_enabled = self.gsdb_get("Enable Teams?", False)
         if teams_enabled:
             member_to_team = team_manager.member_to_team

--- a/AU2/plugins/custom_plugins/ScoringPlugin.py
+++ b/AU2/plugins/custom_plugins/ScoringPlugin.py
@@ -144,12 +144,7 @@ def generate_killtree_visualiser(events: List[Event], score_manager: ScoreManage
                     value=1 + score_manager.get_conkers(victim_model)
                 )
                 added_nodes.add(victim)
-            headline, _ = render_headline_and_reports(
-                e,
-                death_manager=DeathManager(),
-                competency_manager=competency_manager,
-                wanted_manager=wanted_manager
-            )
+            headline, _ = render_headline_and_reports(e, plugin_managers=(competency_manager, wanted_manager))
             plaintext_headline = lxml.html.fromstring(f"<html>{headline}</html>").text_content()
             net.add_edge(killer_searchable, victim_searchable,
                          label=e.datetime.strftime(DATETIME_FORMAT),

--- a/AU2/plugins/custom_plugins/html_templates/may_week_utils_news.html
+++ b/AU2/plugins/custom_plugins/html_templates/may_week_utils_news.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<link rel="preconnect" href="https://fonts.googleapis.com">
+	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+	<link href="https://fonts.googleapis.com/css2?family=Aref+Ruqaa+Ink:wght@700&family=Roboto+Slab&display=swap" rel="stylesheet">
+	<link rel="stylesheet" type="text/css" href="newassassins.css">
+ 	<link rel="shortcut icon" href="img/cloak3.png">
+	<script src="main.js"></script>
+ 	<title>The Assassins' Guild</title>
+</head>
+<body>
+<div class="backgroundimg">
+<div class="wrapper">
+
+	<div w3-include-html="header.html"></div>
+
+	<h2>May Week News</h2>
+
+	{CONTENT}
+
+	<!--Footer-->
+	<div class="footer">
+		<h5>Assassins' Guild {YEAR}</h5>
+	</div>
+</div>
+</div>
+
+<script>
+	includeHTML();
+</script>
+</body></html>

--- a/AU2/plugins/util/render_utils.py
+++ b/AU2/plugins/util/render_utils.py
@@ -186,14 +186,14 @@ ColorFn = Callable[[str, Assassin, Event, Sequence[Manager]], str]
 
 
 def render_headline_and_reports(e: Event,
-                                plugin_managers: Optional[Sequence[Manager]] = None,
+                                plugin_managers: Sequence[Manager] = tuple(),
                                 color_fn: ColorFn = default_color_fn) -> (str, Dict[Tuple[str, int], str]):
     """
     Produces the HTML renderings of an events headline and its reports
 
     Args:
         e (Event): the event to render the headline and reports of
-        plugin_managers (Optional[Sequence[Manager]]): A sequence of managers that have been updated up to the event
+        plugin_managers (Sequence[Manager]): A sequence of managers that have been updated up to the event
             `e`. When called by PageGeneratorPlugin this will contain a CompetencyManager, DeathManager, and
             WantedManager, but other plugins may use it differently.
         color_fn (ColorFn): A function taking a pseudonym, assassin model, event model and a sequence of Managers, and
@@ -251,7 +251,7 @@ def render_headline_and_reports(e: Event,
 
 
 def render_event(e: Event,
-                 plugin_managers: Optional[Sequence[Manager]] = None,
+                 plugin_managers: Sequence[Manager] = tuple(),
                  color_fn: ColorFn = default_color_fn) -> (str, str):
     """
     Renders the full HTML for the event, including headline and reports
@@ -259,7 +259,7 @@ def render_event(e: Event,
 
     Args:
         e (Event): the event to render as html
-        plugin_managers (Optional[Sequence[Manager]]): A sequence of managers that have been updated up to the event
+        plugin_managers (Sequence[Manager]): A sequence of managers that have been updated up to the event
             `e`. When called by PageGeneratorPlugin this will contain a CompetencyManager, DeathManager, and
             WantedManager, but other plugins may use it differently.
         color_fn (ColorFn): A function taking a pseudonym, assassin model, event model and a sequence of Managers, and
@@ -313,7 +313,7 @@ def render_event(e: Event,
 
 def render_all_events(exclude: Callable[[Event], bool],
                       color_fn: ColorFn = default_color_fn,
-                      plugin_managers: Optional[Sequence[Manager]] = None) -> (List[str], Dict[int, List[str]]):
+                      plugin_managers: Sequence[Manager] = tuple()) -> (List[str], Dict[int, List[str]]):
     """
     Produces a rendering of all events not excluded by `exclude`.
 
@@ -321,9 +321,12 @@ def render_all_events(exclude: Callable[[Event], bool],
         exclude: a function taking an Event as input and returning a boolean for whether or not it should be rendered.
         color_fn (ColorFn): A function taking a pseudonym, assassin model, event model and a sequence of Managers, and
             returning a colour hexcode (including #). Defaults to `default_color_fn`.
-        plugin_managers (Optional[Sequence[Manager]]): Sequence of additional, newly-initialised Managers that will be
-            passed into `color_fn` along with a CompetencyManager, DeathManager, and WantedManager. Events are added to
-            these managers in chronological order.
+        plugin_managers (Sequence[Manager]): Sequence of additional, newly-initialised Managers that will be
+            passed into `color_fn` along with a CompetencyManager, DeathManager, and WantedManager.
+
+            Defaults to an empty tuple in which case only the managers just named will be used.
+
+            Events are added to these managers in chronological order.
 
     Returns:
         A tuple of: a list of strings where each element is the HTML rendering of one day's headlines, and a dict

--- a/AU2/plugins/util/render_utils.py
+++ b/AU2/plugins/util/render_utils.py
@@ -1,4 +1,3 @@
-from abc import abstractmethod
 import datetime
 import itertools
 import re
@@ -95,10 +94,8 @@ class Manager(Protocol):
     Interface for managers to process game state for correct player colouring.
     Implemented by CompetencyManager, DeathManager, WantedManager, and also TeamManager from MayWeekUtilitiesPlugin
     """
-    @abstractmethod
     def add_event(self, e: Event):
         """Interface for having a manager process an event."""
-        raise NotImplementedError
 
 
 def default_color_fn(pseudonym: str,

--- a/AU2/plugins/util/render_utils.py
+++ b/AU2/plugins/util/render_utils.py
@@ -104,7 +104,7 @@ def default_color_fn(pseudonym: str,
         if isinstance(manager, DeathManager):
             dead = manager.is_dead(assassin_model)
         elif isinstance(manager, CompetencyManager):
-            incompetent = manager.is_inco_at(assassin_model, e.datetime),
+            incompetent = manager.is_inco_at(assassin_model, e.datetime)
         elif isinstance(manager, WantedManager):
             is_wanted = manager.is_player_wanted(assassin_model.identifier, time=e.datetime)
 


### PR DESCRIPTION
**Problem:** The problem is twofold
1. `PageGeneratorPlugin` paginates news into weeks (and puts a 'Week N' heading at the top), which isn't suitable for May Week, where the news should all be on one page
2. `PageGeneratorPlugin` colours names incorrectly -- not just wrt having names coloured in team colours, but also because casual players get rendered in police colours, and permadeath applies

**Solution:** Have `MayWeekUtilitiesPlugin` generate its own news page. I have modified `render_utils` to make it possible for the plugin to override colouring but otherwise use common news generation code.

Team colours are rendered according to the player's team at the time of the event, rather than when the page is generated.

I have also taken the opportunity to resolve #99.

**Testing:** Manual. Modification of `render_utils` impacts `ScoringPlugin` and `BountyNewsPlugin` so I also tested that these still work.

**Limitations:** 
- `BountyNewsPlugin` still renders in the default `PageGeneratorPlugin` colours. 
- Team memberships are resolved chronologically by datetime rather than in order of creation, even though the latter is what is used by the scoring logic.
- `PageGeneratorPlugin`  still needs to be activated to be able to set events as hidden.