### PR TITLE
[153] Include [police] in human-readable identifier of police players

### DIFF
--- a/AU2/database/model/Assassin.py
+++ b/AU2/database/model/Assassin.py
@@ -60,7 +60,7 @@ class Assassin(PersistentFile):
         # Don't move this out of __post_init__
         if not self.identifier:
             dotdotdot = "..." if len(self.pseudonyms[0]) > 15 else ""
-            self.identifier = f"{self.real_name} ({self.pseudonyms[0][:15]}{dotdotdot}) ID: {self._secret_id}"
+            self.identifier = f"{self.real_name} ({self.pseudonyms[0][:15]}{dotdotdot}){' [police]' if self.is_police else ''} ID: {self._secret_id}"
 
     def clone(self, **changes):
         """


### PR DESCRIPTION
This is to make it easy to tell at a glance whether a player is police or not.

One possible issue however is that it is technically still possible to switch a player between full player and police provided that no targets have been sent out yet, leading to the identifier being misleading...