### PR TITLE
[165] [`TargetingPlugin`] Process kills in chunks

### DIFF
--- a/AU2/plugins/custom_plugins/TargetingPlugin.py
+++ b/AU2/plugins/custom_plugins/TargetingPlugin.py
@@ -329,12 +329,13 @@ class TargetingPlugin(AbstractPlugin):
             if not deaths:
                 continue
 
-            # process one death at a time, to prevent `update_graph` needing to check too many permutations
-            for d in deaths:
-                death = [d]
+            # process deaths in chunks, to prevent `update_graph` needing to check too many permutations
+            n = 3
+            subdivided_deaths = [deaths[i:i + n] for i in range(0, len(deaths), n)]
+            for deaths in subdivided_deaths:
                 # try to fix with triangle elimination
                 # this function has side effects
-                success = self.update_graph(response, targeting_graph, targeters_graph, death, player_seeds_set)
+                success = self.update_graph(response, targeting_graph, targeters_graph, deaths, player_seeds_set)
                 if success:
                     continue
 
@@ -342,7 +343,7 @@ class TargetingPlugin(AbstractPlugin):
                     response,
                     targeting_graph,
                     targeters_graph,
-                    death,
+                    deaths,
                     player_seeds_set,
                     allow_mutual_seed_targets=True
                 )
@@ -356,7 +357,7 @@ class TargetingPlugin(AbstractPlugin):
                     response,
                     targeting_graph,
                     targeters_graph,
-                    death,
+                    deaths,
                     player_seeds_set,
                     allow_mutual_seed_targets=True,
                     allow_mutual_targets=True

--- a/AU2/test/plugins/util/custom_plugins/test_TargetingPlugin.py
+++ b/AU2/test/plugins/util/custom_plugins/test_TargetingPlugin.py
@@ -128,4 +128,4 @@ class TestTargetingPlugin:
         assert valid_targets(num_players - kills, targets)
 
         # test passes only if calculation took a reasonable amount of time
-        assert perf < 0.1
+        assert perf < 0.05


### PR DESCRIPTION
**Problem:** It was noted even back in #71 that having events with more than 3 kills causes problems with the targeting algorithm. More recently, as documented in #165, in the current game computing the targeting graph has become slow due to an event containing 4 deaths.

**Solution:** Have the targeting algorithm process deaths in chunks of 3, rather than processing all the deaths in an event together.

**Testing:** The existing tests in `test_TargetingPlugin.py` still pass, and I have added an additional test for speedup due to chunking which is passed by this PR but failed by the old `TargetingPlugin`.