### PR TITLE
[144] Config option for escaping HTML

### DIFF
--- a/AU2/plugins/CorePlugin.py
+++ b/AU2/plugins/CorePlugin.py
@@ -34,7 +34,8 @@ from AU2.plugins.AbstractPlugin import AbstractPlugin, Export, ConfigExport, Hoo
 from AU2.plugins.AvailablePlugins import __PluginMap
 from AU2.plugins.constants import COLLEGES, WATER_STATUSES
 from AU2.plugins.sanity_checks import SANITY_CHECKS
-from AU2.plugins.util.game import get_game_start, set_game_start, get_game_end, set_game_end
+from AU2.plugins.util.game import get_allow_html, get_game_end, get_game_start, HTML_REPORT_PREFIX, set_allow_html, \
+    set_game_end, set_game_start
 from AU2.plugins.util.date_utils import get_now_dt
 
 AVAILABLE_PLUGINS = {}
@@ -260,6 +261,12 @@ class CorePlugin(AbstractPlugin):
                 "CorePlugin -> Set game end",
                 self.ask_set_game_end,
                 self.answer_set_game_end
+            ),
+            ConfigExport(
+                "core_plugin_set_allow_html",
+                "CorePlugin -> Allow/disallow HTML",
+                self.ask_set_html_allowed,
+                self.answer_set_html_allowed
             ),
             ConfigExport(
                 "core_plugin_suppress_exports",
@@ -506,11 +513,13 @@ class CorePlugin(AbstractPlugin):
     def on_request_setup_game(self, game_type: str) -> List[HTMLComponent]:
         return [
             *self.ask_set_game_start(),
+            *self.ask_set_html_allowed(),
         ]
 
     def on_setup_game(self, htmlResponse) -> List[HTMLComponent]:
         return [
             *self.answer_set_game_start(htmlResponse),
+            *self.answer_set_html_allowed(htmlResponse),
         ]
 
     def get_all_exports(self, include_suppressed: bool = False) -> List[Export]:
@@ -973,6 +982,20 @@ class CorePlugin(AbstractPlugin):
             Label(f"[CORE] Set game end to {new_end.strftime('%Y-%m-%d %H:%M:%S')}") if new_end
             else Label(f"[CORE] Unset game end.")
         ]
+
+    def ask_set_html_allowed(self) -> List[HTMLComponent]:
+        return [
+            Label("Below you can enable HTML in player reports and pseudonyms. "
+                  f"Any HTML reports / pseudonyms must be prefixed by {HTML_REPORT_PREFIX} to render correctly. "
+                  "HTML in headlines will always be rendered, "
+                  "regardless of this setting and without needing to be prefixed."),
+            Checkbox(self.identifier + "_allow_html", "Allow HTML in reports and pseudonyms?", get_allow_html())
+        ]
+
+    def answer_set_html_allowed(self, html_response) -> List[HTMLComponent]:
+        allow = html_response[self.identifier + "_allow_html"]
+        set_allow_html(allow)
+        return [Label(f"[CORE] {'A' if allow else 'Disa'}llowing HTML in pseudonyms / reports.")]
 
     def gather_game_types(self) -> List[str]:
         return list(GAME_TYPE_PLUGIN_MAP)

--- a/AU2/plugins/util/game.py
+++ b/AU2/plugins/util/game.py
@@ -12,16 +12,17 @@ HTML_REPORT_PREFIX = "<!--HTML-->"
 
 def soft_escape(string: str) -> str:
     """
-    Escapes html and adds <br /> to newlines unless prefixed by HTML_REPORT_PREFIX and html is enabled
+    Escapes html and adds <br /> to newlines unless prefixed by HTML_REPORT_PREFIX *and* html is enabled using the
+    config option CorePlugin -> Allow/disallow HTML.
     """
 
     # umpires may regret allowing this
     # supposing you are a clever player who has found this and the umpire does not know...
     # please spare the umpire any headaches
     # and remember that code injection without explicit consent is illegal (CMA sxn 2/3)
-    if not (get_allow_html() and string.startswith(HTML_REPORT_PREFIX)):
-        return escape(string).replace("\n", "<br />\n")
-    return string
+    if get_allow_html() and string.startswith(HTML_REPORT_PREFIX):
+        return string
+    return escape(string).replace("\n", "<br />\n")
 
 
 def set_allow_html(value: bool):

--- a/AU2/plugins/util/game.py
+++ b/AU2/plugins/util/game.py
@@ -12,16 +12,30 @@ HTML_REPORT_PREFIX = "<!--HTML-->"
 
 def soft_escape(string: str) -> str:
     """
-    Escapes html and adds <br /> to newlines only if not prefixed by HTML_REPORT_PREFIX
+    Escapes html and adds <br /> to newlines unless prefixed by HTML_REPORT_PREFIX and html is enabled
     """
 
     # umpires may regret allowing this
     # supposing you are a clever player who has found this and the umpire does not know...
     # please spare the umpire any headaches
     # and remember that code injection without explicit consent is illegal (CMA sxn 2/3)
-    if not string.startswith(HTML_REPORT_PREFIX):
+    if not (get_allow_html() and string.startswith(HTML_REPORT_PREFIX)):
         return escape(string).replace("\n", "<br />\n")
     return string
+
+
+def set_allow_html(value: bool):
+    """
+    Use this to set whether soft_escape should allow HTML when text is prefixed by HTML_REPORT_PREFIX
+    """
+    GENERIC_STATE_DATABASE.arb_state["allow_html"] = value
+
+
+def get_allow_html() -> bool:
+    """
+    Returns whether soft_escape should allow HTML when text is prefixed by HTML_REPORT_PREFIX
+    """
+    return GENERIC_STATE_DATABASE.arb_state.get("allow_html", False)
 
 
 def get_game_start() -> datetime.datetime:


### PR DESCRIPTION
This is an implementation of #144. The config option also appears in `Setup Game` which is also a way of informing the user of the necessity of prefixing player reports / pseudonyms containing HTML with `<!--HTML-->`.