### PR TITLE
Option to not colour real names

### DIFF
--- a/AU2/plugins/util/render_utils.py
+++ b/AU2/plugins/util/render_utils.py
@@ -5,6 +5,7 @@ from typing import Callable, Dict, Iterable, List, Optional, Sequence, Tuple, Pr
 
 from AU2.database.AssassinsDatabase import ASSASSINS_DATABASE
 from AU2.database.EventsDatabase import EVENTS_DATABASE
+from AU2.database.GenericStateDatabase import GENERIC_STATE_DATABASE
 from AU2.database.model import Event, Assassin
 from AU2.plugins.util.CompetencyManager import CompetencyManager
 from AU2.plugins.util.DeathManager import DeathManager
@@ -150,6 +151,14 @@ def get_color(pseudonym: str,
     return HEX_COLS[ind % len(HEX_COLS)]
 
 
+def get_color_real_names() -> bool:
+    return bool(GENERIC_STATE_DATABASE.arb_int_state.get("COLOR_REAL_NAMES", 1))
+
+
+def set_color_real_names(val: bool):
+    GENERIC_STATE_DATABASE.arb_int_state["COLOR_REAL_NAMES"] = int(val)
+
+
 def substitute_pseudonyms(string: str, main_pseudonym: str, assassin: Assassin, color: str, dt: Optional[datetime.datetime] = None) -> str:
     """
     Renders [PX], [DX], [NX], [PX_i] pseudonym codes as HTML, for a single assassin
@@ -174,7 +183,10 @@ def substitute_pseudonyms(string: str, main_pseudonym: str, assassin: Assassin, 
     string = string.replace(f"[D{id_}]",
                             " AKA ".join(PSEUDONYM_TEMPLATE.format(COLOR=color, PSEUDONYM=soft_escape(p)) for p in assassin.pseudonyms_until(dt)))
     string = string.replace(f"[N{id_}]",
-                            PSEUDONYM_TEMPLATE.format(COLOR=color, PSEUDONYM=soft_escape(assassin.real_name)))
+                            PSEUDONYM_TEMPLATE.format(
+                                COLOR=color if get_color_real_names() else "",
+                                PSEUDONYM=soft_escape(assassin.real_name)
+                            ))
     return string
 
 


### PR DESCRIPTION
I made a suggestion in #95 that a way of making real names stand out more could be to render them uncoloured (but still in bold; see my comment on that issue for an example screenshot). This PR adds a config option allowing umpires to choose to render real names like this, with the default option being the current rendering (i.e. a player's real name being coloured the same as their pseudonym).