### PR TITLE
[`PolicePlugin`] Ignore blank lines when setting ranks

### DIFF
--- a/AU2/plugins/custom_plugins/PolicePlugin.py
+++ b/AU2/plugins/custom_plugins/PolicePlugin.py
@@ -184,7 +184,8 @@ class PolicePlugin(AbstractPlugin):
 
     def answer_set_ranks(self, htmlResponse):
         answer = htmlResponse[self.html_ids['Ranks']].split("\n")
-        answer = [i_stripped for i in answer if (i_stripped := i.strip()) and not i_stripped.startswith('#')]
+        answer = (i.strip() for i in answer)
+        answer = [i for i in answer if i and not i.startswith('#')]
         if len(answer) < 3:
             return [Label("[POLICE] Rename failed - Must have enough ranks")]
 


### PR DESCRIPTION
A small PR so that the confusion that just happened doesn't happen again, where because one of the umpires is using Ubuntu the police rank name editor opens vim, which added a blank line at the end of the list of ranks and AU2 thought that was meant to be the umpire rank.