### PR TITLE
[`DeathManager`] Ignore multiple deaths in one event when listing death events

### DIFF
--- a/AU2/plugins/util/DeathManager.py
+++ b/AU2/plugins/util/DeathManager.py
@@ -11,7 +11,7 @@ class DeathManager:
     def add_event(self, e: Event):
         event_deaths = set()
         for (killer, victim) in e.kills:
-            if not victim in event_deaths:
+            if victim not in event_deaths:
                 self.deaths[victim].append(e)
                 event_deaths.add(victim)
 


### PR DESCRIPTION
**Problem:** I've noticed that on the [current city watch page](https://assassins.soc.srcf.net/citywatch.html), Axel's death is listed three times because three people killed them, even though they only died once.

**Solution:** This PR updates `DeathManager` to only add each event at most once to the list of death events for each player, which leads to `CityWatchPlugin` (and also `ScoringPlugin`) only listing the event once on the city watch (resp. stats) page.

**Testing:** I regenerated the city watch page with this change and saw it generated correctly.