### PR TITLE
[Compatibility] Fall back to showing computed targets in `AssassinDependentCrimeEntry` when no targets have been emailed

### DIFF
--- a/AU2/plugins/custom_plugins/TargetingPlugin.py
+++ b/AU2/plugins/custom_plugins/TargetingPlugin.py
@@ -177,11 +177,17 @@ class TargetingPlugin(AbstractPlugin):
     def on_data_hook(self, hook: str, data):
         if hook == "WantedPlugin_targeting_graph":
             # note: targeting graph is only requested when using Event -> Create
-            data["targeting_graph"] = {
+            graph = {
                 assassin.identifier: assassin.__last_emailed_targets
                 for assassin in ASSASSINS_DATABASE.get_filtered(include=lambda a: a.__last_emailed_targets,
                                                                 include_hidden=True)
             }
+
+            # backwards compatibility for a smoother transition during live game
+            if not graph:
+                graph = self.compute_targets([])
+
+            data["targeting_graph"] = graph
 
     def danger_explanation(self) -> str:
         if int(GENERIC_STATE_DATABASE.arb_state.get(self.identifier, {}).get("last_emailed_event", -1)) > -1:


### PR DESCRIPTION
In order to smooth the transition for the umpires from being shown computed targets in the UI to actually emailed targets as per #203, which would result in no targets being shown until emails are next sent out, this PR introduces a fallback to computed targets when AU2 hasn't yet stored any emailed-out targets. This can be removed after the next release.