### PR TITLE
Fix crash when generating stats page with hidden deaths

### DIFF
--- a/AU2/plugins/custom_plugins/CityWatchPlugin.py
+++ b/AU2/plugins/custom_plugins/CityWatchPlugin.py
@@ -20,8 +20,8 @@ from AU2.plugins.constants import WEBPAGE_WRITE_LOCATION
 from AU2.plugins.util.CityWatchRankManager import DEFAULT_RANKS, CityWatchRankManager, DEFAULT_CITY_WATCH_RANK, AUTO_RANK_DEFAULT, \
     MANUAL_RANK_DEFAULT, CITY_WATCH_KILLS_RANKUP_DEFAULT
 from AU2.plugins.util.DeathManager import DeathManager
-from AU2.plugins.util.date_utils import get_now_dt, PRETTY_DATETIME_FORMAT
-from AU2.plugins.util.render_utils import event_url
+from AU2.plugins.util.date_utils import get_now_dt
+from AU2.plugins.util.render_utils import event_datetime_link
 
 CITY_WATCH_TABLE_TEMPLATE = """
 <p xmlns="">
@@ -298,8 +298,7 @@ class CityWatchPlugin(AbstractPlugin):
             city_watch.sort(key=lambda a: (-int(city_watch_rank_manager.get_relative_rank(a.identifier)), a.real_name))
             rows = []
             for a in city_watch:
-                deaths = [f'<a href="{event_url(e)}">{e.datetime.strftime(PRETTY_DATETIME_FORMAT)}</a>'
-                          for e in death_manager.get_death_events(a)]
+                deaths = [event_datetime_link(e) for e in death_manager.get_death_events(a)]
                 rows.append(
                     CITY_WATCH_TABLE_ROW_TEMPLATE.format(
                         RANK=city_watch_rank_manager.get_rank_name(a.identifier),

--- a/AU2/plugins/custom_plugins/ScoringPlugin.py
+++ b/AU2/plugins/custom_plugins/ScoringPlugin.py
@@ -21,13 +21,12 @@ from AU2.html_components.SimpleComponents.Checkbox import Checkbox
 from AU2.plugins.AbstractPlugin import AbstractPlugin, Export, ConfigExport, NavbarEntry
 from AU2.plugins.CorePlugin import registered_plugin
 from AU2.plugins.constants import WEBPAGE_WRITE_LOCATION
-from AU2.plugins.util.render_utils import get_color, render_headline_and_reports, event_url
 from AU2.plugins.util.ScoreManager import ScoreManager
 from AU2.plugins.util.CompetencyManager import CompetencyManager
 from AU2.plugins.util.WantedManager import WantedManager
-from AU2.plugins.util.DeathManager import DeathManager
-from AU2.plugins.util.date_utils import get_now_dt, timestamp_to_dt, dt_to_timestamp, DATETIME_FORMAT, PRETTY_DATETIME_FORMAT
+from AU2.plugins.util.date_utils import get_now_dt, timestamp_to_dt, dt_to_timestamp, DATETIME_FORMAT
 from AU2.plugins.util.game import get_game_start, get_game_end
+from AU2.plugins.util.render_utils import event_datetime_link, get_color, render_headline_and_reports
 
 OPENSEASON_TABLE_TEMPLATE = """
 <table xmlns="" class="playerlist">
@@ -329,7 +328,7 @@ class ScoringPlugin(AbstractPlugin):
             # list of datetimes at which the player died, if applicable,
             # each with a link to the corresponding event on the news pages
             # note: the link may be broken for may week games... (see https://github.com/jsyiek/AU2/issues/161)
-            deaths = [f'<a href="{event_url(e)}">{e.datetime.strftime(PRETTY_DATETIME_FORMAT)}</a>'
+            deaths = [event_datetime_link(e)
                       if openseason_end is None or e.datetime < openseason_end
                       else "Duel"
                       for e in score_manager.get_death_events(p)]

--- a/AU2/plugins/util/render_utils.py
+++ b/AU2/plugins/util/render_utils.py
@@ -13,7 +13,7 @@ from AU2.plugins.util.CompetencyManager import CompetencyManager
 from AU2.plugins.util.DeathManager import DeathManager
 from AU2.plugins.util.WantedManager import WantedManager
 from AU2.plugins.constants import WEBPAGE_WRITE_LOCATION
-from AU2.plugins.util.date_utils import datetime_to_time_str, date_to_weeks_and_days, get_now_dt
+from AU2.plugins.util.date_utils import datetime_to_time_str, date_to_weeks_and_days, get_now_dt, PRETTY_DATETIME_FORMAT
 from AU2.plugins.util.game import get_game_start, soft_escape
 
 NEWS_TEMPLATE: str
@@ -110,8 +110,19 @@ def event_url(e: Event, page: Optional[str] = None) -> str:
     """
     Generates the (relative) url pointing to this event's appearance on the news pages.
     """
-    page = page or default_page_allocator(e).nav_entry.url
+    if not page:
+        ch = default_page_allocator(e)
+        page = ch.nav_entry.url if ch else ""
     return f"{page}#{e._Event__secret_id}"
+
+
+def event_datetime_link(e: Event) -> str:
+    """
+    Creates an HTML <a> tag linking to a sepecified event
+    """
+    url = event_url(e)
+    dt = e.datetime.strftime(PRETTY_DATETIME_FORMAT)
+    return f'<a href="{url}">{dt}</a>' if url else dt
 
 
 class Manager(Protocol):

--- a/AU2/plugins/util/render_utils.py
+++ b/AU2/plugins/util/render_utils.py
@@ -112,7 +112,9 @@ def event_url(e: Event, page: Optional[str] = None) -> str:
     """
     if not page:
         ch = default_page_allocator(e)
-        page = ch.nav_entry.url if ch else ""
+        if not ch:
+            return ""
+        page = ch.nav_entry.url
     return f"{page}#{e._Event__secret_id}"
 
 

--- a/AU2/plugins/util/render_utils.py
+++ b/AU2/plugins/util/render_utils.py
@@ -106,14 +106,14 @@ def default_page_allocator(e: Event) -> Optional[Chapter]:
         return Chapter(f"Week {week} News", NavbarEntry(f"news{week:02}.html", f"Week {week} Reports", week))
 
 
-def event_url(e: Event, page: Optional[str] = None) -> str:
+def event_url(e: Event, page: Optional[str] = None) -> Optional[str]:
     """
     Generates the (relative) url pointing to this event's appearance on the news pages.
     """
     if not page:
         ch = default_page_allocator(e)
         if not ch:
-            return ""
+            return None
         page = ch.nav_entry.url
     return f"{page}#{e._Event__secret_id}"
 

--- a/AU2/test/plugins/util/test_render_utils.py
+++ b/AU2/test/plugins/util/test_render_utils.py
@@ -1,5 +1,5 @@
-from AU2.plugins.util.render_utils import adjust_brightness
-
+from AU2.plugins.util.render_utils import adjust_brightness, event_url
+from AU2.test.test_utils import dummy_event, plugin_test
 
 class TestRenderUtils:
     def test_adjust_brightness(self):
@@ -9,3 +9,10 @@ class TestRenderUtils:
         assert adjust_brightness("#a81245", 255).lower() == "#ffffff"
         assert adjust_brightness("#15a28b", 0.5).lower() == "#0a5145"
         assert adjust_brightness("#88bc0f", 1/3).lower() == "#2d3e05"
+
+    @plugin_test
+    def test_hidden_event_url(self):
+        event = dummy_event()
+        event.pluginState = {"PageGeneratorPlugin": {"HIDDEN": True}}
+        # test passes so long as this doesn't crash AU2
+        event_url(event)


### PR DESCRIPTION
This is the branch that [v1.6.3-pre1](https://github.com/jsyiek/AU2/releases/tag/v1.6.3-pre1) is based off.

**Problem:** Generating the stats page caused a crash in the current game. Reading the coredump sent by Joel, this seems to be triggered by trying to generate a url for hidden events.

**Solution:** Twofold: firstly, I have fixed the `event_url` function to not crash on hidden events, and secondly have `ScoringPlugin` not generate a link for hidden deaths.

**Testing:** I have added a unit test for `event_url` to prevent regression, and manualy tested that page generation is correct using the database for the current game.