### PR TITLE
[227/222] KillEntry supporting thunderbolting

### DIFF
--- a/AU2/database/model/Event.py
+++ b/AU2/database/model/Event.py
@@ -2,11 +2,14 @@ from dataclasses import dataclass, field
 
 import datetime as dt
 from dataclasses_json import dataclass_json, config
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, NamedTuple, Optional, Tuple
 
 from AU2.database.GenericStateDatabase import GENERIC_STATE_DATABASE
 from AU2.database.model import PersistentFile
 from AU2.plugins.util.date_utils import dt_to_timestamp, timestamp_to_dt
+
+
+Kill = NamedTuple("Kill", (("killer", Optional[str]), ("victim", str)))
 
 
 @dataclass_json
@@ -34,7 +37,11 @@ class Event(PersistentFile):
     reports: List[Tuple[str, Optional[int], str]]
 
     # Map from killer to victim
-    kills: List[Tuple[str, str]]
+    kills: List[Kill] = field(
+        metadata=config(
+            decoder=lambda l: [Kill(*t) for t in l],
+        )
+    )
 
     # to allow plugins to make notes on the event
     pluginState: Dict[str, Any] = field(default_factory=dict)

--- a/AU2/database/model/Event.py
+++ b/AU2/database/model/Event.py
@@ -33,7 +33,7 @@ class Event(PersistentFile):
     # from assassin ID and their pseudonym ID to their report
     reports: List[Tuple[str, Optional[int], str]]
 
-    # Map from killer to victim. If killer is empty (""), represents a thunderbolt.
+    # Map from killer to victim
     kills: List[Tuple[str, str]]
 
     # to allow plugins to make notes on the event

--- a/AU2/database/model/Event.py
+++ b/AU2/database/model/Event.py
@@ -9,6 +9,7 @@ from AU2.database.model import PersistentFile
 from AU2.plugins.util.date_utils import dt_to_timestamp, timestamp_to_dt
 
 
+# 'thunderbolt' kills are implemented with a null value for the killer
 Kill = NamedTuple("Kill", (("killer", Optional[str]), ("victim", str)))
 
 
@@ -36,7 +37,6 @@ class Event(PersistentFile):
     # from assassin ID and their pseudonym ID to their report
     reports: List[Tuple[str, Optional[int], str]]
 
-    # Map from killer to victim
     kills: List[Kill] = field(
         metadata=config(
             decoder=lambda l: [Kill(*t) for t in l],

--- a/AU2/database/model/Event.py
+++ b/AU2/database/model/Event.py
@@ -33,7 +33,7 @@ class Event(PersistentFile):
     # from assassin ID and their pseudonym ID to their report
     reports: List[Tuple[str, Optional[int], str]]
 
-    # Map from killer to victim
+    # Map from killer to victim. If killer is empty (""), represents a thunderbolt.
     kills: List[Tuple[str, str]]
 
     # to allow plugins to make notes on the event

--- a/AU2/frontends/inquirer_cli.py
+++ b/AU2/frontends/inquirer_cli.py
@@ -356,7 +356,7 @@ def render(html_component, dependency_context={}):
         q = [inquirer.List(
             name=victim,
             message=f"Who killed {escape_format_braces(victim)}?",
-            choices=[a for a in assassins if a != victim] + [("(Thunderbolt)", "")],
+            choices=[a for a in assassins if a != victim],
             default=default_killers[victim],
         ) for victim in deaths]
         victim_killer_mapping = inquirer_prompt_with_abort(q)
@@ -409,8 +409,6 @@ def render(html_component, dependency_context={}):
         mapping = {}
         defaults = []
         for (a1, a2) in kills:
-            if html_component.ignore_thunderbolts and not a1:
-                continue
             key = f"{a1} kills {a2}"
             mapping[key] = (a1, a2)
             if (a1, a2) in html_component.default:

--- a/AU2/frontends/inquirer_cli.py
+++ b/AU2/frontends/inquirer_cli.py
@@ -356,8 +356,10 @@ def render(html_component, dependency_context={}):
         q = [inquirer.List(
             name=victim,
             message=f"Who killed {escape_format_braces(victim)}?",
-            choices=[a for a in assassins if a != victim],
-            default=default_killers[victim],
+            # note: we use 'self-kills' for thunderbolts, for backwards compatibility.
+            # so long as thunderbolt events aren't edited on an older version of AU2 it will be able to cope with this
+            choices=[a for a in assassins if a != victim] + [("(Thunderbolt)", victim)],
+            default=default_killers.get(victim),
         ) for victim in deaths]
         victim_killer_mapping = inquirer_prompt_with_abort(q)
         return {html_component.identifier: [(killer, victim) for victim, killer in victim_killer_mapping.items()]}
@@ -409,6 +411,8 @@ def render(html_component, dependency_context={}):
         mapping = {}
         defaults = []
         for (a1, a2) in kills:
+            if html_component.exclude_thunderbolts and a1 == a2:
+                continue
             key = f"{a1} kills {a2}"
             mapping[key] = (a1, a2)
             if (a1, a2) in html_component.default:

--- a/AU2/frontends/inquirer_cli.py
+++ b/AU2/frontends/inquirer_cli.py
@@ -345,25 +345,20 @@ def render(html_component, dependency_context={}):
         assassins = list(assassins_mapping.keys())
         if len(assassins) <= 1:
             return {html_component.identifier: tuple(), "skip": True}
-        potential_kills = {}
-        defaults = []
-        for a1 in assassins:
-            for a2 in assassins:
-                if a1 != a2:
-                    key = f"{a1} kills {a2}"
-                    potential_kills[key] = (a1, a2)
-                    if (a1, a2) in html_component.default:
-                        defaults.append(key)
         q = [inquirer.Checkbox(
             name="q",
-            message="Select kills",
-            choices=list(potential_kills.keys()),
-            default=defaults
+            message="Select players who DIED in this event",
+            choices=assassins,
+            default=[victim for _, victim in html_component.default],
         )]
-        # TODO: Confirm what happens if option in default isn't in choices
-        a = inquirer_prompt_with_abort(q)["q"]
-        a = tuple(potential_kills[k] for k in a)
-        return {html_component.identifier: a}
+        deaths = inquirer_prompt_with_abort(q)["q"]
+        q = [inquirer.List(
+            name=victim,
+            message=f"Who killed {escape_format_braces(victim)}?",
+            choices=[a for a in assassins if a != victim],
+        ) for victim in deaths]
+        victim_killer_mapping = inquirer_prompt_with_abort(q)
+        return {html_component.identifier: [(killer, victim) for victim, killer in victim_killer_mapping.items()]}
 
     # dependent component
     elif isinstance(html_component, AssassinDependentTransferEntry):

--- a/AU2/frontends/inquirer_cli.py
+++ b/AU2/frontends/inquirer_cli.py
@@ -15,6 +15,7 @@ from inquirer.errors import ValidationError, EndOfInput
 
 from AU2 import TIMEZONE
 from AU2.database.AssassinsDatabase import ASSASSINS_DATABASE
+from AU2.database.model.Event import Kill
 from AU2.database import save_all_databases
 from AU2.html_components import HTMLComponent
 from AU2.html_components.DependentComponents.AssassinDependentTransferEntry import AssassinDependentTransferEntry
@@ -356,11 +357,11 @@ def render(html_component, dependency_context={}):
         q = [inquirer.List(
             name=victim,
             message=f"Who killed {escape_format_braces(victim)}?",
-            choices=[a for a in assassins if a != victim],
+            choices=[a for a in assassins if a != victim] + [("(Thunderbolt)", None)],
             default=default_killers[victim],
         ) for victim in deaths]
         victim_killer_mapping = inquirer_prompt_with_abort(q)
-        return {html_component.identifier: [(killer, victim) for victim, killer in victim_killer_mapping.items()]}
+        return {html_component.identifier: [Kill(killer, victim) for victim, killer in victim_killer_mapping.items()]}
 
     # dependent component
     elif isinstance(html_component, AssassinDependentTransferEntry):
@@ -409,6 +410,8 @@ def render(html_component, dependency_context={}):
         mapping = {}
         defaults = []
         for (a1, a2) in kills:
+            if html_component.ignore_thunderbolts and not a1:
+                continue
             key = f"{a1} kills {a2}"
             mapping[key] = (a1, a2)
             if (a1, a2) in html_component.default:

--- a/AU2/frontends/inquirer_cli.py
+++ b/AU2/frontends/inquirer_cli.py
@@ -356,7 +356,7 @@ def render(html_component, dependency_context={}):
         q = [inquirer.List(
             name=victim,
             message=f"Who killed {escape_format_braces(victim)}?",
-            choices=[a for a in assassins if a != victim],
+            choices=[a for a in assassins if a != victim] + [("(Thunderbolt)", "")],
             default=default_killers[victim],
         ) for victim in deaths]
         victim_killer_mapping = inquirer_prompt_with_abort(q)
@@ -409,6 +409,8 @@ def render(html_component, dependency_context={}):
         mapping = {}
         defaults = []
         for (a1, a2) in kills:
+            if html_component.ignore_thunderbolts and not a1:
+                continue
             key = f"{a1} kills {a2}"
             mapping[key] = (a1, a2)
             if (a1, a2) in html_component.default:

--- a/AU2/frontends/inquirer_cli.py
+++ b/AU2/frontends/inquirer_cli.py
@@ -351,11 +351,13 @@ def render(html_component, dependency_context={}):
             choices=assassins,
             default=[victim for _, victim in html_component.default],
         )]
-        deaths = inquirer_prompt_with_abort(q)["q"]
+        deaths = set(inquirer_prompt_with_abort(q)["q"])
+        default_killers = {victim: killer for killer, victim in html_component.default if victim in deaths}
         q = [inquirer.List(
             name=victim,
             message=f"Who killed {escape_format_braces(victim)}?",
             choices=[a for a in assassins if a != victim],
+            default=default_killers[victim],
         ) for victim in deaths]
         victim_killer_mapping = inquirer_prompt_with_abort(q)
         return {html_component.identifier: [(killer, victim) for victim, killer in victim_killer_mapping.items()]}

--- a/AU2/frontends/inquirer_cli.py
+++ b/AU2/frontends/inquirer_cli.py
@@ -356,10 +356,8 @@ def render(html_component, dependency_context={}):
         q = [inquirer.List(
             name=victim,
             message=f"Who killed {escape_format_braces(victim)}?",
-            # note: we use 'self-kills' for thunderbolts, for backwards compatibility.
-            # so long as thunderbolt events aren't edited on an older version of AU2 it will be able to cope with this
-            choices=[a for a in assassins if a != victim] + [("(Thunderbolt)", victim)],
-            default=default_killers.get(victim),
+            choices=[a for a in assassins if a != victim],
+            default=default_killers[victim],
         ) for victim in deaths]
         victim_killer_mapping = inquirer_prompt_with_abort(q)
         return {html_component.identifier: [(killer, victim) for victim, killer in victim_killer_mapping.items()]}
@@ -411,8 +409,6 @@ def render(html_component, dependency_context={}):
         mapping = {}
         defaults = []
         for (a1, a2) in kills:
-            if html_component.exclude_thunderbolts and a1 == a2:
-                continue
             key = f"{a1} kills {a2}"
             mapping[key] = (a1, a2)
             if (a1, a2) in html_component.default:

--- a/AU2/html_components/DependentComponents/KillDependentSelector.py
+++ b/AU2/html_components/DependentComponents/KillDependentSelector.py
@@ -7,12 +7,13 @@ from AU2.html_components import HTMLComponent
 class KillDependentSelector(HTMLComponent):
     name: str = "KillDependentSelector"
 
-    def __init__(self, kills_identifier: str, identifier: str, title: str, default: List[Tuple[str, str]]=[]):
+    def __init__(self, kills_identifier: str, identifier: str, title: str, default: List[Tuple[str, str]]=[], ignore_thunderbolts: bool = True):
         self.kills_identifier = escape(kills_identifier)
         self.title = title
         self.identifier = identifier
         self.uniqueStr = self.get_unique_str()
         self.default = default
+        self.ignore_thunderbolts = ignore_thunderbolts
         super().__init__()
 
     def _representation(self) -> str:

--- a/AU2/html_components/DependentComponents/KillDependentSelector.py
+++ b/AU2/html_components/DependentComponents/KillDependentSelector.py
@@ -7,13 +7,12 @@ from AU2.html_components import HTMLComponent
 class KillDependentSelector(HTMLComponent):
     name: str = "KillDependentSelector"
 
-    def __init__(self, kills_identifier: str, identifier: str, title: str, default: List[Tuple[str, str]]=[], ignore_thunderbolts: bool = True):
+    def __init__(self, kills_identifier: str, identifier: str, title: str, default: List[Tuple[str, str]]=[]):
         self.kills_identifier = escape(kills_identifier)
         self.title = title
         self.identifier = identifier
         self.uniqueStr = self.get_unique_str()
         self.default = default
-        self.ignore_thunderbolts = ignore_thunderbolts
         super().__init__()
 
     def _representation(self) -> str:

--- a/AU2/html_components/DependentComponents/KillDependentSelector.py
+++ b/AU2/html_components/DependentComponents/KillDependentSelector.py
@@ -7,12 +7,14 @@ from AU2.html_components import HTMLComponent
 class KillDependentSelector(HTMLComponent):
     name: str = "KillDependentSelector"
 
-    def __init__(self, kills_identifier: str, identifier: str, title: str, default: List[Tuple[str, str]]=[]):
+    def __init__(self, kills_identifier: str, identifier: str, title: str, default: List[Tuple[str, str]]=[],
+                 exclude_thunderbolts: bool = True):
         self.kills_identifier = escape(kills_identifier)
         self.title = title
         self.identifier = identifier
         self.uniqueStr = self.get_unique_str()
         self.default = default
+        self.exclude_thunderbolts = exclude_thunderbolts
         super().__init__()
 
     def _representation(self) -> str:

--- a/AU2/html_components/DependentComponents/KillDependentSelector.py
+++ b/AU2/html_components/DependentComponents/KillDependentSelector.py
@@ -7,14 +7,12 @@ from AU2.html_components import HTMLComponent
 class KillDependentSelector(HTMLComponent):
     name: str = "KillDependentSelector"
 
-    def __init__(self, kills_identifier: str, identifier: str, title: str, default: List[Tuple[str, str]]=[],
-                 exclude_thunderbolts: bool = True):
+    def __init__(self, kills_identifier: str, identifier: str, title: str, default: List[Tuple[str, str]]=[]):
         self.kills_identifier = escape(kills_identifier)
         self.title = title
         self.identifier = identifier
         self.uniqueStr = self.get_unique_str()
         self.default = default
-        self.exclude_thunderbolts = exclude_thunderbolts
         super().__init__()
 
     def _representation(self) -> str:

--- a/AU2/plugins/CorePlugin.py
+++ b/AU2/plugins/CorePlugin.py
@@ -349,9 +349,9 @@ class CorePlugin(AbstractPlugin):
             response.append((f"Report {i+1}", f"{a.snapshot()} as {pseudonym}"))
 
         for (i, (killer_id, victim_id)) in enumerate(event.kills):
-            killer = ASSASSINS_DATABASE.get(killer_id)
+            killer_snapshot = ASSASSINS_DATABASE.get(killer_id).snapshot() if killer_id else "THUNDERBOLT"
             victim = ASSASSINS_DATABASE.get(victim_id)
-            response.append((f"Kill {i+1}", f"{killer.snapshot()} kills {victim.snapshot()}"))
+            response.append((f"Kill {i+1}", f"{killer_snapshot} kills {victim.snapshot()}"))
         return response
 
     def ask_core_plugin_summary_event(self) -> List[HTMLComponent]:

--- a/AU2/plugins/CorePlugin.py
+++ b/AU2/plugins/CorePlugin.py
@@ -349,9 +349,9 @@ class CorePlugin(AbstractPlugin):
             response.append((f"Report {i+1}", f"{a.snapshot()} as {pseudonym}"))
 
         for (i, (killer_id, victim_id)) in enumerate(event.kills):
-            killer = ASSASSINS_DATABASE.get(killer_id)
+            killer_snapshot = ASSASSINS_DATABASE.get(killer_id).snapshot() if killer_id != victim_id else "THUNDERBOLT"
             victim = ASSASSINS_DATABASE.get(victim_id)
-            response.append((f"Kill {i+1}", f"{killer.snapshot()} kills {victim.snapshot()}"))
+            response.append((f"Kill {i+1}", f"{killer_snapshot} kills {victim.snapshot()}"))
         return response
 
     def ask_core_plugin_summary_event(self) -> List[HTMLComponent]:

--- a/AU2/plugins/CorePlugin.py
+++ b/AU2/plugins/CorePlugin.py
@@ -349,9 +349,9 @@ class CorePlugin(AbstractPlugin):
             response.append((f"Report {i+1}", f"{a.snapshot()} as {pseudonym}"))
 
         for (i, (killer_id, victim_id)) in enumerate(event.kills):
-            killer_snapshot = ASSASSINS_DATABASE.get(killer_id).snapshot() if killer_id else "THUNDERBOLT"
+            killer = ASSASSINS_DATABASE.get(killer_id)
             victim = ASSASSINS_DATABASE.get(victim_id)
-            response.append((f"Kill {i+1}", f"{killer_snapshot} kills {victim.snapshot()}"))
+            response.append((f"Kill {i+1}", f"{killer.snapshot()} kills {victim.snapshot()}"))
         return response
 
     def ask_core_plugin_summary_event(self) -> List[HTMLComponent]:

--- a/AU2/plugins/CorePlugin.py
+++ b/AU2/plugins/CorePlugin.py
@@ -349,9 +349,9 @@ class CorePlugin(AbstractPlugin):
             response.append((f"Report {i+1}", f"{a.snapshot()} as {pseudonym}"))
 
         for (i, (killer_id, victim_id)) in enumerate(event.kills):
-            killer_snapshot = ASSASSINS_DATABASE.get(killer_id).snapshot() if killer_id != victim_id else "THUNDERBOLT"
+            killer = ASSASSINS_DATABASE.get(killer_id)
             victim = ASSASSINS_DATABASE.get(victim_id)
-            response.append((f"Kill {i+1}", f"{killer_snapshot} kills {victim.snapshot()}"))
+            response.append((f"Kill {i+1}", f"{killer.snapshot()} kills {victim.snapshot()}"))
         return response
 
     def ask_core_plugin_summary_event(self) -> List[HTMLComponent]:

--- a/AU2/plugins/custom_plugins/CompetencyPlugin.py
+++ b/AU2/plugins/custom_plugins/CompetencyPlugin.py
@@ -258,13 +258,6 @@ class CompetencyPlugin(AbstractPlugin):
             options=available_assassins,
             defaults=[i for i in available_assassins if not i in active_players]
         ))
-        questions.append(InputWithDropDown(
-            title="Select the umpire, since someone needs to kill the selected players",
-            identifier=self.html_ids["Umpire"],
-            options=[i for i in ASSASSINS_DATABASE.get_identifiers() if ASSASSINS_DATABASE.get(i).is_city_watch],
-            selected=GENERIC_STATE_DATABASE.arb_state.get("CityWatchPlugin", {}).get("CityWatchPlugin_umpires", [""])[0]
-            # Will crash if there are no city watch to choose from
-        ))
         questions.append(DatetimeEntry(
             identifier=self.html_ids["Datetime"],
             title="Enter date/time of event")
@@ -279,27 +272,19 @@ class CompetencyPlugin(AbstractPlugin):
 
     def gigabolt_answer(self, htmlResponse):
         deaths = htmlResponse[self.html_ids['Gigabolt']]
-        umpire = htmlResponse[self.html_ids['Umpire']]
         # remove lines beginning with '#'
         headline = '\n'.join([i for i in htmlResponse[self.html_ids['Headline']].split('\n') if not i.startswith('#')])
         headline = headline.replace('[num_players]', str(len(deaths)))
-        # TODO Adjust targeting plugin so that it can handle events with many deaths, by retargeting in chunks
-        # I don't want to mess with the targeting plugin mid-game, so making a bunch of events with n kills each works for now
-        # Number of deaths per event:
-        n = 3
-        # Brief testing showed that 5 was too large (and broke targeting). 1 makes an annoying number of events
-        subdivided_deaths = [deaths[i:i + n] for i in range(0, len(deaths), n)]
-        for idx, i in enumerate(subdivided_deaths):
-            EVENTS_DATABASE.add(
-                Event(
-                    assassins={j: 0 for j in i} | {umpire: 0},
-                    datetime=htmlResponse[self.html_ids['Datetime']],
-                    headline=f"Gigabolt stage {idx+1}" if (idx or not headline) else headline,
-                    reports={},
-                    kills=[(umpire, j) for j in i],
-                    pluginState={"PageGeneratorPlugin": {"hidden_event": bool(idx) or not headline}}
-                )
+        EVENTS_DATABASE.add(
+            Event(
+                assassins={v: 0 for v in deaths},
+                datetime=htmlResponse[self.html_ids['Datetime']],
+                headline=headline or "GIGABOLT",
+                reports={},
+                kills=[("", v) for v in deaths],
+                pluginState={"PageGeneratorPlugin": {"hidden_event": not headline}}
             )
+        )
 
         return [Label(f"[COMPETENCY] Gigabolt Success! {len(deaths)} players eliminated")]
 

--- a/AU2/plugins/custom_plugins/CompetencyPlugin.py
+++ b/AU2/plugins/custom_plugins/CompetencyPlugin.py
@@ -8,7 +8,7 @@ from AU2 import ROOT_DIR
 from AU2.database.AssassinsDatabase import ASSASSINS_DATABASE
 from AU2.database.EventsDatabase import EVENTS_DATABASE
 from AU2.database.GenericStateDatabase import GENERIC_STATE_DATABASE
-from AU2.database.model import Event, Assassin
+from AU2.database.model import Assassin, Event, Kill
 from AU2.html_components import HTMLComponent
 from AU2.html_components.DependentComponents.AssassinDependentIntegerEntry import AssassinDependentIntegerEntry
 from AU2.html_components.SimpleComponents.Checkbox import Checkbox
@@ -110,7 +110,8 @@ def get_active_players(death_manager: DeathManager) -> Set[str]:
     for e in sorted(list(EVENTS_DATABASE.events.values()), key=lambda event: event.datetime):
         death_manager.add_event(e)
         for killer, _ in e.kills:
-            active_players.append(killer)
+            if killer:
+                active_players.append(killer)
         for player_id in e.pluginState.get("CompetencyPlugin", {}).get("attempts", []):
             active_players.append(player_id)
     return set(active_players)
@@ -279,7 +280,7 @@ class CompetencyPlugin(AbstractPlugin):
                 datetime=htmlResponse[self.html_ids['Datetime']],
                 headline=headline or "GIGABOLT",
                 reports={},
-                kills=[("", v) for v in deaths],
+                kills=[Kill(None, v) for v in deaths],
                 pluginState={"PageGeneratorPlugin": {"hidden_event": not headline}}
             )
         )

--- a/AU2/plugins/custom_plugins/CompetencyPlugin.py
+++ b/AU2/plugins/custom_plugins/CompetencyPlugin.py
@@ -177,7 +177,6 @@ class CompetencyPlugin(AbstractPlugin):
             "Attempts": self.identifier + "_attempts",
             "Gigabolt": self.identifier + "_gigabolt",
             "Headline": self.identifier + "_gigabolt_headline",
-            "Umpire": self.identifier + "_umpire",
             "Search": self.identifier + "_search"
         }
 

--- a/AU2/plugins/custom_plugins/CompetencyPlugin.py
+++ b/AU2/plugins/custom_plugins/CompetencyPlugin.py
@@ -110,7 +110,8 @@ def get_active_players(death_manager: DeathManager) -> Set[str]:
     for e in sorted(list(EVENTS_DATABASE.events.values()), key=lambda event: event.datetime):
         death_manager.add_event(e)
         for killer, _ in e.kills:
-            active_players.append(killer)
+            if killer:
+                active_players.append(killer)
         for player_id in e.pluginState.get("CompetencyPlugin", {}).get("attempts", []):
             active_players.append(player_id)
     return set(active_players)

--- a/AU2/plugins/custom_plugins/CompetencyPlugin.py
+++ b/AU2/plugins/custom_plugins/CompetencyPlugin.py
@@ -279,7 +279,8 @@ class CompetencyPlugin(AbstractPlugin):
                 datetime=htmlResponse[self.html_ids['Datetime']],
                 headline=headline or "GIGABOLT",
                 reports={},
-                kills=[("", v) for v in deaths],
+                # we use 'self kills' for thunderbolt for backwards-compatibility
+                kills=[(v, v) for v in deaths],
                 pluginState={"PageGeneratorPlugin": {"hidden_event": not headline}}
             )
         )

--- a/AU2/plugins/custom_plugins/CompetencyPlugin.py
+++ b/AU2/plugins/custom_plugins/CompetencyPlugin.py
@@ -279,8 +279,7 @@ class CompetencyPlugin(AbstractPlugin):
                 datetime=htmlResponse[self.html_ids['Datetime']],
                 headline=headline or "GIGABOLT",
                 reports={},
-                # we use 'self kills' for thunderbolt for backwards-compatibility
-                kills=[(v, v) for v in deaths],
+                kills=[("", v) for v in deaths],
                 pluginState={"PageGeneratorPlugin": {"hidden_event": not headline}}
             )
         )

--- a/AU2/plugins/custom_plugins/CompetencyPlugin.py
+++ b/AU2/plugins/custom_plugins/CompetencyPlugin.py
@@ -110,8 +110,7 @@ def get_active_players(death_manager: DeathManager) -> Set[str]:
     for e in sorted(list(EVENTS_DATABASE.events.values()), key=lambda event: event.datetime):
         death_manager.add_event(e)
         for killer, _ in e.kills:
-            if killer:
-                active_players.append(killer)
+            active_players.append(killer)
         for player_id in e.pluginState.get("CompetencyPlugin", {}).get("attempts", []):
             active_players.append(player_id)
     return set(active_players)

--- a/AU2/plugins/custom_plugins/MafiaPlugin.py
+++ b/AU2/plugins/custom_plugins/MafiaPlugin.py
@@ -497,6 +497,9 @@ class MafiaPlugin(AbstractPlugin):
             deaths = []
             point_gains = {}
             for (killer, victim) in e.kills:
+                if not killer:
+                    continue
+
                 multiplier = 1
 
                 if victim in current_capos:

--- a/AU2/plugins/custom_plugins/MafiaPlugin.py
+++ b/AU2/plugins/custom_plugins/MafiaPlugin.py
@@ -497,9 +497,6 @@ class MafiaPlugin(AbstractPlugin):
             deaths = []
             point_gains = {}
             for (killer, victim) in e.kills:
-                if not killer:
-                    continue
-
                 multiplier = 1
 
                 if victim in current_capos:

--- a/AU2/plugins/custom_plugins/MayWeekUtilitiesPlugin.py
+++ b/AU2/plugins/custom_plugins/MayWeekUtilitiesPlugin.py
@@ -621,10 +621,12 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
 
             for (killer, victim) in e.kills:
                 is_as_team = teams_enabled and (killer, victim) in kills_made_as_team
-                is_with_multiplier = killer in multiplier_owners
-                if team_multiplier_sharing_enabled and not is_with_multiplier:
-                    # check whether the killer is in the same team as someone with a multiplier
-                    is_with_multiplier = any(memb in multiplier_owners for memb in team_to_members[member_to_team[killer]])
+                is_with_multiplier = False
+                if killer:
+                    is_with_multiplier = killer in multiplier_owners
+                    if team_multiplier_sharing_enabled and not is_with_multiplier:
+                        # check whether the killer is in the same team as someone with a multiplier
+                        is_with_multiplier = any(memb in multiplier_owners for memb in team_to_members[member_to_team[killer]])
 
                 # apply team and multiplier bonuses (% and fixed) iff they apply
                 # (side note: maybe calling the items that grant bonuses multipliers is a little confusing in this
@@ -635,7 +637,8 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
                 m_now = m if is_with_multiplier else 1
                 M_now = M if is_with_multiplier else 0
 
-                point_deltas[killer] = point_deltas.get(killer, 0) + ((scores[victim]*b + B)*t_now + T_now)*m_now + M_now
+                if killer:
+                    point_deltas[killer] = point_deltas.get(killer, 0) + ((scores[victim]*b + B)*t_now + T_now)*m_now + M_now
                 point_deltas[victim] = point_deltas.get(victim, 0) - scores[victim]*d - D
 
             # resolve deltas once all worked out

--- a/AU2/plugins/custom_plugins/MayWeekUtilitiesPlugin.py
+++ b/AU2/plugins/custom_plugins/MayWeekUtilitiesPlugin.py
@@ -635,12 +635,7 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
                 m_now = m if is_with_multiplier else 1
                 M_now = M if is_with_multiplier else 0
 
-                # we use 'self-kills' for thunderbolts.
-                # thunderbolting shouldn't really be a thing in may week,
-                # but it seems the logical handling is to have players be treated as a victim only
-                if killer != victim:
-                    point_deltas[killer] = point_deltas.get(killer, 0) + ((scores[victim]*b + B)*t_now + T_now)*m_now + M_now
-
+                point_deltas[killer] = point_deltas.get(killer, 0) + ((scores[victim]*b + B)*t_now + T_now)*m_now + M_now
                 point_deltas[victim] = point_deltas.get(victim, 0) - scores[victim]*d - D
 
             # resolve deltas once all worked out

--- a/AU2/plugins/custom_plugins/MayWeekUtilitiesPlugin.py
+++ b/AU2/plugins/custom_plugins/MayWeekUtilitiesPlugin.py
@@ -635,7 +635,12 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
                 m_now = m if is_with_multiplier else 1
                 M_now = M if is_with_multiplier else 0
 
-                point_deltas[killer] = point_deltas.get(killer, 0) + ((scores[victim]*b + B)*t_now + T_now)*m_now + M_now
+                # we use 'self-kills' for thunderbolts.
+                # thunderbolting shouldn't really be a thing in may week,
+                # but it seems the logical handling is to have players be treated as a victim only
+                if killer != victim:
+                    point_deltas[killer] = point_deltas.get(killer, 0) + ((scores[victim]*b + B)*t_now + T_now)*m_now + M_now
+
                 point_deltas[victim] = point_deltas.get(victim, 0) - scores[victim]*d - D
 
             # resolve deltas once all worked out

--- a/AU2/plugins/custom_plugins/MayWeekUtilitiesPlugin.py
+++ b/AU2/plugins/custom_plugins/MayWeekUtilitiesPlugin.py
@@ -621,12 +621,10 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
 
             for (killer, victim) in e.kills:
                 is_as_team = teams_enabled and (killer, victim) in kills_made_as_team
-                is_with_multiplier = False
-                if killer:
-                    is_with_multiplier = killer in multiplier_owners
-                    if team_multiplier_sharing_enabled and not is_with_multiplier:
-                        # check whether the killer is in the same team as someone with a multiplier
-                        is_with_multiplier = any(memb in multiplier_owners for memb in team_to_members[member_to_team[killer]])
+                is_with_multiplier = killer in multiplier_owners
+                if team_multiplier_sharing_enabled and not is_with_multiplier:
+                    # check whether the killer is in the same team as someone with a multiplier
+                    is_with_multiplier = any(memb in multiplier_owners for memb in team_to_members[member_to_team[killer]])
 
                 # apply team and multiplier bonuses (% and fixed) iff they apply
                 # (side note: maybe calling the items that grant bonuses multipliers is a little confusing in this
@@ -637,8 +635,7 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
                 m_now = m if is_with_multiplier else 1
                 M_now = M if is_with_multiplier else 0
 
-                if killer:
-                    point_deltas[killer] = point_deltas.get(killer, 0) + ((scores[victim]*b + B)*t_now + T_now)*m_now + M_now
+                point_deltas[killer] = point_deltas.get(killer, 0) + ((scores[victim]*b + B)*t_now + T_now)*m_now + M_now
                 point_deltas[victim] = point_deltas.get(victim, 0) - scores[victim]*d - D
 
             # resolve deltas once all worked out

--- a/AU2/plugins/custom_plugins/ScoringPlugin.py
+++ b/AU2/plugins/custom_plugins/ScoringPlugin.py
@@ -126,6 +126,11 @@ def generate_killtree_visualiser(events: List[Event], score_manager: ScoreManage
         for (killer, victim) in e.kills:
             competency_manager.add_event(e)
             wanted_manager.add_event(e)
+
+            # ignore thunderbolts
+            if not killer:
+                continue
+
             killer_model = ASSASSINS_DATABASE.get(killer)
             victim_model = ASSASSINS_DATABASE.get(victim)
             killer_searchable = f"{killer_model.all_pseudonyms(fn=lambda x: x)} ({killer_model.real_name})"

--- a/AU2/plugins/custom_plugins/ScoringPlugin.py
+++ b/AU2/plugins/custom_plugins/ScoringPlugin.py
@@ -126,11 +126,6 @@ def generate_killtree_visualiser(events: List[Event], score_manager: ScoreManage
         for (killer, victim) in e.kills:
             competency_manager.add_event(e)
             wanted_manager.add_event(e)
-
-            # ignore thunderbolts
-            if not killer:
-                continue
-
             killer_model = ASSASSINS_DATABASE.get(killer)
             victim_model = ASSASSINS_DATABASE.get(victim)
             killer_searchable = f"{killer_model.all_pseudonyms(fn=lambda x: x)} ({killer_model.real_name})"

--- a/AU2/plugins/util/CityWatchRankManager.py
+++ b/AU2/plugins/util/CityWatchRankManager.py
@@ -32,7 +32,7 @@ class CityWatchRankManager:
             self.assassin_relative_ranks[aID] += rank
         if self.auto_ranking:
             for (killer, victim) in e.kills:
-                if not killer or not ASSASSINS_DATABASE.get(killer).is_city_watch:
+                if not ASSASSINS_DATABASE.get(killer).is_city_watch:
                     continue
                 if (killer in GENERIC_STATE_DATABASE.arb_state.get("CityWatchPlugin", {}).get("CityWatchPlugin_umpires", [])
                         or killer in GENERIC_STATE_DATABASE.arb_state.get("CityWatchPlugin", {}).get("CityWatchPlugin_cop", [])):

--- a/AU2/plugins/util/CityWatchRankManager.py
+++ b/AU2/plugins/util/CityWatchRankManager.py
@@ -32,7 +32,7 @@ class CityWatchRankManager:
             self.assassin_relative_ranks[aID] += rank
         if self.auto_ranking:
             for (killer, victim) in e.kills:
-                if not ASSASSINS_DATABASE.get(killer).is_city_watch:
+                if not killer or not ASSASSINS_DATABASE.get(killer).is_city_watch:
                     continue
                 if (killer in GENERIC_STATE_DATABASE.arb_state.get("CityWatchPlugin", {}).get("CityWatchPlugin_umpires", [])
                         or killer in GENERIC_STATE_DATABASE.arb_state.get("CityWatchPlugin", {}).get("CityWatchPlugin_cop", [])):

--- a/AU2/plugins/util/CompetencyManager.py
+++ b/AU2/plugins/util/CompetencyManager.py
@@ -44,7 +44,7 @@ class CompetencyManager:
         if self.auto_competency:
             for (killer, victim) in e.kills:
                 victim_model = ASSASSINS_DATABASE.get(victim)
-                if victim_model.is_city_watch or self.death_manager.is_dead(victim_model) or not killer:
+                if victim_model.is_city_watch or self.death_manager.is_dead(victim_model):
                     continue
                 self.attempts_since_kill[killer] = 0
                 # Allows overriding auto competency on a case-by-case basis

--- a/AU2/plugins/util/CompetencyManager.py
+++ b/AU2/plugins/util/CompetencyManager.py
@@ -44,7 +44,7 @@ class CompetencyManager:
         if self.auto_competency:
             for (killer, victim) in e.kills:
                 victim_model = ASSASSINS_DATABASE.get(victim)
-                if victim_model.is_city_watch or self.death_manager.is_dead(victim_model):
+                if victim_model.is_city_watch or self.death_manager.is_dead(victim_model) or not killer:
                     continue
                 self.attempts_since_kill[killer] = 0
                 # Allows overriding auto competency on a case-by-case basis

--- a/AU2/plugins/util/DeathManager.py
+++ b/AU2/plugins/util/DeathManager.py
@@ -10,7 +10,7 @@ class DeathManager:
 
     def add_event(self, e: Event):
         event_deaths = set()
-        for (killer, victim) in e.kills:
+        for (_, victim) in e.kills:
             if victim not in event_deaths:
                 self.deaths[victim].append(e)
                 event_deaths.add(victim)

--- a/AU2/plugins/util/DeathManager.py
+++ b/AU2/plugins/util/DeathManager.py
@@ -10,7 +10,7 @@ class DeathManager:
 
     def add_event(self, e: Event):
         event_deaths = set()
-        for (_, victim) in e.kills:
+        for (killer, victim) in e.kills:
             if victim not in event_deaths:
                 self.deaths[victim].append(e)
                 event_deaths.add(victim)

--- a/AU2/plugins/util/ScoreManager.py
+++ b/AU2/plugins/util/ScoreManager.py
@@ -34,9 +34,7 @@ class ScoreManager:
             # and dead players will be pruned as events are added
             if victim not in self.live_assassins:
                 continue
-            # we use self-kills to represent thunderbolts, so need to ignore these kills
-            if victim != killer:
-                self.kill_tree[killer].append(victim)
+            self.kill_tree[killer].append(victim)
             if self.perma_death:
                 self.live_assassins.discard(victim)
         for assassin_id in e.pluginState.get("CompetencyPlugin", {}).get("attempts", []):

--- a/AU2/plugins/util/ScoreManager.py
+++ b/AU2/plugins/util/ScoreManager.py
@@ -34,7 +34,9 @@ class ScoreManager:
             # and dead players will be pruned as events are added
             if victim not in self.live_assassins:
                 continue
-            self.kill_tree[killer].append(victim)
+            # we use self-kills to represent thunderbolts, so need to ignore these kills
+            if victim != killer:
+                self.kill_tree[killer].append(victim)
             if self.perma_death:
                 self.live_assassins.discard(victim)
         for assassin_id in e.pluginState.get("CompetencyPlugin", {}).get("attempts", []):

--- a/AU2/plugins/util/ScoreManager.py
+++ b/AU2/plugins/util/ScoreManager.py
@@ -34,10 +34,9 @@ class ScoreManager:
             # and dead players will be pruned as events are added
             if victim not in self.live_assassins:
                 continue
+            self.kill_tree[killer].append(victim)
             if self.perma_death:
                 self.live_assassins.discard(victim)
-            if killer:
-                self.kill_tree[killer].append(victim)
         for assassin_id in e.pluginState.get("CompetencyPlugin", {}).get("attempts", []):
             self.attempt_counter[assassin_id] = self.attempt_counter.get(assassin_id, 0) + 1
 

--- a/AU2/plugins/util/ScoreManager.py
+++ b/AU2/plugins/util/ScoreManager.py
@@ -34,9 +34,10 @@ class ScoreManager:
             # and dead players will be pruned as events are added
             if victim not in self.live_assassins:
                 continue
-            self.kill_tree[killer].append(victim)
             if self.perma_death:
                 self.live_assassins.discard(victim)
+            if killer:
+                self.kill_tree[killer].append(victim)
         for assassin_id in e.pluginState.get("CompetencyPlugin", {}).get("attempts", []):
             self.attempt_counter[assassin_id] = self.attempt_counter.get(assassin_id, 0) + 1
 

--- a/AU2/plugins/util/WantedManager.py
+++ b/AU2/plugins/util/WantedManager.py
@@ -27,7 +27,7 @@ class WantedManager:
                                                  'wanted_duration': datetime.timedelta(days=duration),
                                                  'crime': crime,
                                                  'redemption': redemption})
-        for (killer, victim) in e.kills:
+        for (_, victim) in e.kills:
             self.wanted_events.setdefault(victim, [])
             self.wanted_events[victim].append({'event_time': e.datetime})
 

--- a/AU2/plugins/util/WantedManager.py
+++ b/AU2/plugins/util/WantedManager.py
@@ -27,7 +27,7 @@ class WantedManager:
                                                  'wanted_duration': datetime.timedelta(days=duration),
                                                  'crime': crime,
                                                  'redemption': redemption})
-        for (_, victim) in e.kills:
+        for (killer, victim) in e.kills:
             self.wanted_events.setdefault(victim, [])
             self.wanted_events[victim].append({'event_time': e.datetime})
 

--- a/AU2/test/plugins/util/custom_plugins/test_CityWatchPlugin.py
+++ b/AU2/test/plugins/util/custom_plugins/test_CityWatchPlugin.py
@@ -1,13 +1,16 @@
-import datetime
-
 from AU2.database.AssassinsDatabase import ASSASSINS_DATABASE
 from AU2.database.EventsDatabase import EVENTS_DATABASE
-from AU2.database.model import Event
 from AU2.plugins.custom_plugins.CityWatchPlugin import CityWatchPlugin
-from AU2.test.test_utils import MockGame, some_players, plugin_test, dummy_event
+from AU2.plugins.util.CityWatchRankManager import CityWatchRankManager
+from AU2.test.test_utils import MockGame, some_players, plugin_test
 
 
 class TestCityWatchPlugin:
+    def get_manager(self, auto_ranking=True, city_watch_kill_ranking=False) -> CityWatchRankManager:
+        m = CityWatchRankManager(auto_ranking=auto_ranking, city_watch_kill_ranking=city_watch_kill_ranking)
+        for e in EVENTS_DATABASE.events.values():
+            m.add_event(e)
+        return m
 
     @plugin_test
     def test_resurrect_as_city_watch(self):
@@ -71,3 +74,31 @@ class TestCityWatchPlugin:
         # check the list of resurrectable assassins is correct after resurrection
         assert old_assassin.hidden
         assert set(plugin.gather_dead_full_players()) == {p[i] + " identifier" for i in range(k + 1, 2 * k - 1)}
+
+    @plugin_test
+    def test_can_handle_thunderbolt(self):
+        """
+        Have 20 players, players 0-9 city watch, rest full players.
+        Then kill graph
+        0 -> 10
+        |--> 11
+
+        Thunderbolt -> 12
+            |--------> 1
+        """
+        p = some_players(20)
+        game = MockGame().having_assassins(p)
+        game.assassin(p[0]).with_accomplices(*p[1:10]).are_city_watch()
+
+        game.assassin(p[0]).kills(p[10]).then()\
+            .assassin(p[0]).kills(p[11]).then()\
+            .assassin(p[12]).is_thunderbolted().then()\
+            .assassin(p[1]).is_thunderbolted()
+
+        manager = self.get_manager()
+
+        # player 0 has two kills -> two rankups
+        assert manager.get_relative_rank(p[0] + " identifier") == 2
+        # other city watch have no kills
+        for i in range(1, 10):
+            assert manager.get_relative_rank(p[i] + " identifier") == 0

--- a/AU2/test/plugins/util/custom_plugins/test_CityWatchPlugin.py
+++ b/AU2/test/plugins/util/custom_plugins/test_CityWatchPlugin.py
@@ -90,10 +90,10 @@ class TestCityWatchPlugin:
         game = MockGame().having_assassins(p)
         game.assassin(p[0]).with_accomplices(*p[1:10]).are_city_watch()
 
-        game.assassin(p[0]).kills(p[10]).then()\
-            .assassin(p[0]).kills(p[11]).then()\
-            .assassin(p[12]).is_thunderbolted().then()\
-            .assassin(p[1]).is_thunderbolted()
+        game.assassin(p[0]).kills(p[10])\
+            .then().assassin(p[0]).kills(p[11])\
+            .then().assassin(p[12]).is_thunderbolted()\
+            .then().assassin(p[1]).is_thunderbolted()
 
         manager = self.get_manager()
 

--- a/AU2/test/plugins/util/custom_plugins/test_CompetencyPlugin.py
+++ b/AU2/test/plugins/util/custom_plugins/test_CompetencyPlugin.py
@@ -166,7 +166,6 @@ class TestCompetencyPlugin:
         plugin.gigabolt_answer(
             htmlResponse={
                 plugin.html_ids["Gigabolt"]: next((c.defaults for c in plugin.gigabolt_ask() if c.identifier == plugin.html_ids["Gigabolt"])),
-                plugin.html_ids["Umpire"]: p[19],
                 plugin.html_ids["Datetime"]: game.new_datetime(),
                 plugin.html_ids["Headline"]: "",
             }
@@ -263,3 +262,30 @@ class TestCompetencyPlugin:
 
         for i in range(10):
             assert ASSASSINS_DATABASE.get(p[i + 10] + " identifier") in incos
+
+    @plugin_test
+    def test_can_handle_thunderbolt(self):
+        """
+        Test that auto-competency can handle players being thunderbolted,
+        """
+        p = some_players(20)
+        game = MockGame().having_assassins(p)
+
+        # some players gain competency through kills...
+        for i in range(5):
+            game.assassin(p[i]).kills(p[i + 5], manual_competency=None)
+        # some get thunderbolted
+        game.assassin(p[10]).with_accomplices(*p[11:15]).are_thunderbolted()
+
+        manager = self.get_manager(game, auto_competency=True, initial_competency_period=0)
+        query_date = manager.game_start + datetime.timedelta(days=1, seconds=30)
+
+        incos = manager.get_incos_at(query_date)
+
+        for i in range(5):
+            assert ASSASSINS_DATABASE.get(p[i] + " identifier") not in incos
+
+        for i in range(10):
+            assert ASSASSINS_DATABASE.get(p[i + 5] + " identifier") in incos
+
+        assert len(incos) == 15

--- a/AU2/test/plugins/util/custom_plugins/test_CompetencyPlugin.py
+++ b/AU2/test/plugins/util/custom_plugins/test_CompetencyPlugin.py
@@ -283,11 +283,9 @@ class TestCompetencyPlugin:
         incos = manager.get_incos_at(query_date)
 
         for i in range(5):
-            assert game.assassin_model(p[i]) not in incos
+            assert ASSASSINS_DATABASE.get(p[i] + " identifier") not in incos
 
-        for i in range(15, 20):
-            assert game.assassin_model(p[i]) in incos
+        for i in range(10):
+            assert ASSASSINS_DATABASE.get(p[i + 5] + " identifier") in incos
 
-        # thunderbolted players should all be 'inco corpses'
-        for i in range(10, 15):
-            assert game.assassin_model(p[i]) in manager.inco_corpses
+        assert len(incos) == 15

--- a/AU2/test/plugins/util/custom_plugins/test_CompetencyPlugin.py
+++ b/AU2/test/plugins/util/custom_plugins/test_CompetencyPlugin.py
@@ -283,9 +283,11 @@ class TestCompetencyPlugin:
         incos = manager.get_incos_at(query_date)
 
         for i in range(5):
-            assert ASSASSINS_DATABASE.get(p[i] + " identifier") not in incos
+            assert game.assassin_model(p[i]) not in incos
 
-        for i in range(10):
-            assert ASSASSINS_DATABASE.get(p[i + 5] + " identifier") in incos
+        for i in range(15, 20):
+            assert game.assassin_model(p[i]) in incos
 
-        assert len(incos) == 15
+        # thunderbolted players should all be 'inco corpses'
+        for i in range(10, 15):
+            assert game.assassin_model(p[i]) in manager.inco_corpses

--- a/AU2/test/plugins/util/custom_plugins/test_DeathManager.py
+++ b/AU2/test/plugins/util/custom_plugins/test_DeathManager.py
@@ -1,0 +1,33 @@
+from AU2.database.EventsDatabase import EVENTS_DATABASE
+from AU2.plugins.util.DeathManager import DeathManager
+from AU2.test.test_utils import MockGame, plugin_test, some_players
+
+class TestDeathManager:
+    def get_manager(self) -> DeathManager:
+        m = DeathManager()
+        for e in EVENTS_DATABASE.events.values():
+            m.add_event(e)
+        return m
+
+    @plugin_test
+    def test_can_handle_thunderbolt(self):
+        """
+        Test that DeathManager can deal with thunderbolt deaths
+        """
+        p = some_players(20)
+        game = MockGame().having_assassins(p)
+
+        # some kills
+        for i in range(5):
+            game.assassin(p[i]).kills(p[i + 5], manual_competency=None)
+        # some thunderbolts
+        game.assassin(p[10]).with_accomplices(*p[11:15]).are_thunderbolted()
+
+        manager = self.get_manager()
+
+        # check right players counted as dead
+        for i in range(20):
+            if i < 5 or i >= 15:
+                assert not manager.is_dead(game.assassin_model(p[i]))
+            else:
+                assert manager.is_dead(game.assassin_model(p[i]))

--- a/AU2/test/plugins/util/custom_plugins/test_ScoringPlugin.py
+++ b/AU2/test/plugins/util/custom_plugins/test_ScoringPlugin.py
@@ -151,8 +151,8 @@ class TestScoringPlugin:
         (with perma-death turned off)
         Kill graph used is
             0 <-> 1 -> 2
-                 /|\   |
-                  |   \|/
+                  ^    |
+                  |    V
                   4 <- 3
         """
         p = some_players(5)

--- a/AU2/test/plugins/util/custom_plugins/test_ScoringPlugin.py
+++ b/AU2/test/plugins/util/custom_plugins/test_ScoringPlugin.py
@@ -151,8 +151,8 @@ class TestScoringPlugin:
         (with perma-death turned off)
         Kill graph used is
             0 <-> 1 -> 2
-                  ^    |
-                  |    V
+                 /|\   |
+                  |   \|/
                   4 <- 3
         """
         p = some_players(5)

--- a/AU2/test/plugins/util/custom_plugins/test_ScoringPlugin.py
+++ b/AU2/test/plugins/util/custom_plugins/test_ScoringPlugin.py
@@ -2,11 +2,9 @@ import random
 import math
 from typing import Dict
 
-from AU2.database.AssassinsDatabase import ASSASSINS_DATABASE
 from AU2.database.EventsDatabase import EVENTS_DATABASE
-from AU2.plugins.custom_plugins.ScoringPlugin import ScoringPlugin
 from AU2.plugins.util.ScoreManager import ScoreManager
-from AU2.test.test_utils import MockGame, some_players, plugin_test, dummy_event
+from AU2.test.test_utils import MockGame, some_players, plugin_test
 
 
 class TestScoringPlugin:
@@ -239,3 +237,56 @@ class TestScoringPlugin:
 
         # check the open season list is correct
         assert manager.live_assassins == {idents[4], idents[5]}
+
+    @plugin_test
+    def test_can_handle_thunderbolt(self):
+        """
+        Kill graph looks like
+        0 -> 1 -> 2 -> 3
+        Thunderbolt -> 4 -> 5
+             |
+             v
+             6 <- 7
+
+        Where 7 -> 6 occurs *after* the thunderbolt
+        """
+        n = 8
+        p = some_players(n)
+        game = MockGame().having_assassins(p)
+        idents = [name + " identifier" for name in p]
+
+        # add kills
+        game.assassin(p[2]).kills(p[3]).then()\
+            .assassin(p[1]).kills(p[2]).then()\
+            .assassin(p[0]).kills(p[1]).then()\
+            .assassin(p[4]).kills(p[5])
+
+        # add thunderbolts
+        game.assassin(p[4]).is_thunderbolted().then()\
+            .assassin(p[6]).is_thunderbolted()
+
+        # add kill of thunderbolted player
+        game.assassin(p[7]).kills(p[6])
+
+        manager = self.get_manager(game)
+
+        # check kills are counted correctly
+        for i in range(n):
+            if i in {0, 1, 2, 4}:
+                assert manager._kills(idents[i]) == 1
+            else:
+                assert manager._kills(idents[i]) == 0
+
+        # check conkers are calculated correctly
+        for i in range(n):
+            if i in {2, 4}:
+                assert manager._conkers(idents[i]) == 1
+            elif i in {1}:
+                assert manager._conkers(idents[i]) == 2
+            elif i in {0}:
+                assert manager._conkers(idents[i]) == 3
+            else:
+                assert manager._conkers(idents[i]) == 0
+
+        # only players 0 and 7 survive the game
+        assert manager.live_assassins == {idents[0], idents[7]}

--- a/AU2/test/plugins/util/custom_plugins/test_TargetingPlugin.py
+++ b/AU2/test/plugins/util/custom_plugins/test_TargetingPlugin.py
@@ -129,3 +129,31 @@ class TestTargetingPlugin:
 
         # test passes only if calculation took a reasonable amount of time
         assert perf < 1.0
+
+    @plugin_test
+    def test_can_handle_thunderbolt(self):
+        num_players = 50
+        p = some_players(num_players)
+        game = MockGame().having_assassins(p)
+
+        plugin = TargetingPlugin()
+        targets = plugin.compute_targets([])
+        assert valid_targets(num_players, targets)
+
+        game.assassin(p[0]).kills(p[1]).then() \
+            .assassin(p[2]).kills(p[3])
+
+        # add in some thunderbolts
+        thunderbolted = p[30:45]
+        game.assassin(thunderbolted[0]).with_accomplices(*thunderbolted).are_thunderbolted()
+
+        game.assassin(p[4]).kills(p[5]).then() \
+            .assassin(p[6]).kills(p[7])
+
+        targets = plugin.compute_targets([])
+        assert valid_targets(num_players - 4 - len(thunderbolted), targets)
+
+        # verify that thunderbolted players are no longer involved in targeting
+        for name in thunderbolted:
+            assert (name + " identifier") not in targets
+            assert not any((name + " identifier") in targ_list for targ_list in targets.values())

--- a/AU2/test/test_utils.py
+++ b/AU2/test/test_utils.py
@@ -313,6 +313,21 @@ class ProxyAssassin:
 
         return event
 
+    def are_thunderbolted(self, headline: str = "") -> ProxyEvent:
+        event = self.is_involved_in_event(
+            assassins=self.assassins,
+            headline=headline,
+            kills=[("", self.__ident(v)) for v in self.assassins],
+        )
+
+        for v in self.assassins:
+            event.mockGame.has_died(v)
+
+        return event
+
+    def is_thunderbolted(self, *args, **kwargs) -> ProxyEvent:
+        return self.are_thunderbolted(*args, **kwargs)
+
     def is_involved_in_event(self, assassins=None, dt=None, headline="Event Headline", reports=None, kills=None, pluginState=None) -> ProxyEvent:
         """
         Submits a generic event to the database

--- a/AU2/test/test_utils.py
+++ b/AU2/test/test_utils.py
@@ -317,7 +317,7 @@ class ProxyAssassin:
         event = self.is_involved_in_event(
             assassins=self.assassins,
             headline=headline,
-            kills=[("", self.__ident(v)) for v in self.assassins],
+            kills=[(self.__ident(v), self.__ident(v)) for v in self.assassins],
         )
 
         for v in self.assassins:

--- a/AU2/test/test_utils.py
+++ b/AU2/test/test_utils.py
@@ -1,10 +1,10 @@
 import datetime
-from typing import List, Optional, Tuple
+from typing import List, Optional
 
 from AU2 import TIMEZONE
 from AU2.database.AssassinsDatabase import ASSASSINS_DATABASE
 from AU2.database.EventsDatabase import EVENTS_DATABASE
-from AU2.database.model import PersistentFile, Assassin, Event
+from AU2.database.model import Assassin, Event, Kill, PersistentFile
 from AU2.database.model.database_utils import refresh_databases
 from AU2.html_components.HTMLComponent import HTMLComponent
 from AU2.html_components.SimpleComponents.DatetimeEntry import DatetimeEntry
@@ -317,7 +317,7 @@ class ProxyAssassin:
         event = self.is_involved_in_event(
             assassins=self.assassins,
             headline=headline,
-            kills=[("", self.__ident(v)) for v in self.assassins],
+            kills=[Kill(None, self.__ident(v)) for v in self.assassins],
         )
 
         for v in self.assassins:

--- a/AU2/test/test_utils.py
+++ b/AU2/test/test_utils.py
@@ -317,7 +317,7 @@ class ProxyAssassin:
         event = self.is_involved_in_event(
             assassins=self.assassins,
             headline=headline,
-            kills=[(self.__ident(v), self.__ident(v)) for v in self.assassins],
+            kills=[("", self.__ident(v)) for v in self.assassins],
         )
 
         for v in self.assassins:


### PR DESCRIPTION
**Problem:** This PR solves two problems together: firstly, that the KillEntry UI gets unwieldy with many participants, and secondly that the current method of thunderbolting (having the umpire make a kill) turned out to be problematic in #180: hiding death events means they can't be linked to on the stats page, and having a flag for the gigabolt is problematic because it's invisible to the user.

**Solution:** For the first problem, this PR changes `AssassinDependentKillEntry` to have multiple stages, with the user first selecting which players died, and then selecting who killed them. 
I have made it so that in an event each player can only have one killer, since having multiple killers doesn't play well in scoring, although it's worth having a discussion whether it's better to leave the option of multiple kills and formalise how they're dealt with.

For the second problem, the updated kill entry UI gives an option for each death to by thunderbolt, ~~which is implemented in the backend as a player killing themselves.~~
~~Originally I implemented it as having thunderbolts be kills of the form `("", victim)`, but I realised that having thunderbolts be self-kills was more or less compatible with the existing handling of kills, with the only modfifications required being of how kills and conkers are counted for thunderbolted players, but this is minor since the scores of dead players don't really matter. I also updated the May Week scoring to account for thunderbolts, though we wouldn't expect thunderbolting to be a thing in May Week.~~ [see update below]

The gigabolt is updated to use these thunderbolt kills, and hence I took the opportunity to resolve #222 (merging gigabolt deaths into one event) in this PR.

**Testing:** This PR includes several unit tests to verify the ability of the various Managers + the targeting algorithm to cope with thunderbolt deaths, (which I had created when thunderbolts were going to be encoded as `("", victim)`, arguably they are less necessary with self-kills, but we might as well have them). The UI I tested manually.

**Update:** Further to discussions below, kills are now stored as `NamedTuple`s and thunderbolts are implemented with a `None` value for the 'killer'.