### PR TITLE
Mayweek 2026 features

### DIFF
--- a/AU2/database/EventsDatabase.py
+++ b/AU2/database/EventsDatabase.py
@@ -1,6 +1,6 @@
 import os
 from dataclasses import dataclass
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 from dataclasses_json import dataclass_json
 
@@ -27,6 +27,19 @@ class EventsDatabase(PersistentFile):
         Fetches an event given an identifier, if it exists, otherwise returns None
         """
         return self.events.get(identifier, None)
+
+    def events_chronologically(self, last: Optional[Event] = None) -> List[Event]:
+        """
+        Returns events in chronological order.
+
+        Args:
+            last (Optional[Event]): The last event to return. If `None`, all events will be returned.
+        """
+        events_up_to_cutoff = (
+            (e for e in self.events.values()
+             if e.datetime < last.datetime or (e.datetime == last.datetime and e.get_numerical_id() <= last.get_numerical_id()))
+        ) if last else self.events.values()
+        return sorted(events_up_to_cutoff, key=lambda e: (e.datetime, e.get_numerical_id()))
 
     def _refresh(self):
         """

--- a/AU2/frontends/inquirer_cli.py
+++ b/AU2/frontends/inquirer_cli.py
@@ -114,6 +114,18 @@ def float_validator(_, current):
         return False
     return True
 
+def optional_float_validator(_, current):
+    try:
+        if current is None:
+            raise KeyboardInterrupt
+        # allow null values
+        if current == "":
+            return True
+        s = float(current)
+    except ValueError:
+        return False
+    return True
+
 
 def inquirer_prompt_with_abort(*args, **kwargs) -> Any:
     """
@@ -636,7 +648,7 @@ def render(html_component, dependency_context={}):
         q = [inquirer.Text(
             name="int",
             message=escape_format_braces(html_component.title),
-            default=html_component.default,
+            default=str(html_component.default),  # note: str needed to stop 0 being turned into empty string by inquirer
             validate=integer_validator
         )]
         integer = inquirer_prompt_with_abort(q)["int"]
@@ -646,11 +658,12 @@ def render(html_component, dependency_context={}):
         q = [inquirer.Text(
             name="float",
             message=escape_format_braces(html_component.title),
-            default=html_component.default,
-            validate=float_validator
+            # note: str needed to stop 0 being turned into empty string by inquirer
+            default="" if html_component.default is None else str(html_component.default),
+            validate=optional_float_validator if html_component.optional else float_validator
         )]
         number = inquirer_prompt_with_abort(q)["float"]
-        return {html_component.identifier: float(number)}
+        return {html_component.identifier: float(number) if number != "" else None}
 
     elif isinstance(html_component, PathEntry):
         q = [inquirer.Path(

--- a/AU2/frontends/inquirer_cli.py
+++ b/AU2/frontends/inquirer_cli.py
@@ -392,7 +392,12 @@ def render(html_component, dependency_context={}):
         # (also turn into a set so that `in` is faster)
         html_component.default = {tuple(l) for l in html_component.default}
 
-        potential_transfers = {}
+        # TODO: below is the original implementation of this component, however it requires knowledge of the current
+        #       multiplier owners, which forces the MW plugin to (unintuitively!) process events in the order they were
+        #       added rather than their in-game datetimes.
+        #       If https://github.com/jsyiek/AU2/pull/164 this can be fixed, but for now it is replaced by a less
+        #       sophisticated implementation that does not use the current multiplier holders.
+        """potential_transfers = {}
         defaults = []
         owners = [a for a in html_component.owners if a in assassins]
         receivers = [a for a in assassins if a not in owners]
@@ -412,7 +417,27 @@ def render(html_component, dependency_context={}):
         )]
         # TODO: Confirm what happens if option in default isn't in choices
         a = inquirer_prompt_with_abort(q)["q"]
-        a = tuple(potential_transfers[k] for k in a)
+        a = tuple(potential_transfers[k] for k in a)"""
+        # temporary interface: just ask who gained / lost multipliers, without using existing holders
+        default_gainers = {g_id for _, g_id in html_component.default if g_id}
+        default_losers = {l_id for l_id, _ in html_component.default if l_id}
+        print(html_component.title)
+        q = [inquirer.Checkbox(
+            name="gainers",
+            message=f"Select players to GAIN {html_component.transfer_item_name} (if applicable)",
+            choices=assassins,
+            default=list(default_gainers),
+        ), inquirer.Checkbox(
+            name="losers",
+            message=f"Select players to LOSE {html_component.transfer_item_name} (if applicable)",
+            choices=assassins,
+            default=list(default_losers),
+        )]
+        response = inquirer_prompt_with_abort(q)
+
+        # convert into transfers, since this is the expected return format of this component...
+        a = [(None, g_id) for g_id in response["gainers"]] + [(l_id, None) for l_id in response["losers"]]
+
         return {html_component.identifier: a}
 
     # dependent component

--- a/AU2/html_components/DependentComponents/AssassinDependentTransferEntry.py
+++ b/AU2/html_components/DependentComponents/AssassinDependentTransferEntry.py
@@ -7,13 +7,22 @@ from AU2.html_components import HTMLComponent
 class AssassinDependentTransferEntry(HTMLComponent):
     name: str = "Transfer"
 
-    def __init__(self, assassins_list_identifier: str, owners: List[str], identifier: str, title: str, default: List[Tuple[str, str]]=[]):
+    def __init__(
+            self,
+            assassins_list_identifier: str,
+            owners: List[str],
+            identifier: str,
+            title: str,
+            default: List[Tuple[str, str]]=[],
+            transfer_item_name: str = ""  # this is a bodge for the current temporary implementation
+    ):
         self.assassins_list_identifier = escape(assassins_list_identifier)
         self.title = title
         self.owners = owners
         self.identifier = identifier
         self.uniqueStr = self.get_unique_str()
         self.default = default
+        self.transfer_item_name = transfer_item_name
         super().__init__()
 
     def _representation(self) -> str:

--- a/AU2/html_components/SimpleComponents/FloatEntry.py
+++ b/AU2/html_components/SimpleComponents/FloatEntry.py
@@ -1,14 +1,16 @@
+from typing import Optional
 from AU2.html_components import HTMLComponent
 
 
 class FloatEntry(HTMLComponent):
-    name: str = "IntegerEntry"
+    name: str = "FloatEntry"
 
-    def __init__(self, identifier: str, title: str, default: float):
+    def __init__(self, identifier: str, title: str, default: Optional[float], optional: bool = False,):
         self.title = title
         self.identifier = identifier
         self.uniqueStr = self.get_unique_str()
         self.default = default
+        self.optional = optional
         super().__init__()
 
     def _representation(self) -> str:

--- a/AU2/plugins/AbstractPlugin.py
+++ b/AU2/plugins/AbstractPlugin.py
@@ -137,7 +137,7 @@ class AbstractPlugin:
 
     @property
     def enabled(self) -> bool:
-        return GENERIC_STATE_DATABASE.plugin_map.get(self.identifier, True)
+        return GENERIC_STATE_DATABASE.plugin_map.setdefault(self.identifier, False)
 
     @enabled.setter
     def enabled(self, val: bool):

--- a/AU2/plugins/CorePlugin.py
+++ b/AU2/plugins/CorePlugin.py
@@ -91,6 +91,7 @@ GAME_TYPE_PLUGIN_MAP = {
         "WantedPlugin": True,
     }
 }
+REQUIRES_PLAYERS_FIRST = ("Standard Game",)
 BOUNTY_PLUGINS = ("BountyNewsPlugin", "BountyPlugin")
 
 
@@ -1069,9 +1070,9 @@ class CorePlugin(AbstractPlugin):
                 PLUGINS[plugin].enabled = to_enable
                 components.append(Label(f"[CORE] {'En' if to_enable else 'Dis'}abled {plugin}"))
 
-        # require players to be added first.
+        # for certain game types (i.e. those involving city watch or targeting...) require players to be added first.
         # this is done *after* enabling plugins, so that Setup Game can at least help to set up the correct plugins
-        if not ASSASSINS_DATABASE.assassins:
+        if game_type in REQUIRES_PLAYERS_FIRST and not ASSASSINS_DATABASE.assassins:
             components.append(
                 HiddenTextbox(
                     self.config_html_ids["Setup Error"],

--- a/AU2/plugins/CorePlugin.py
+++ b/AU2/plugins/CorePlugin.py
@@ -77,21 +77,19 @@ GAME_TYPE_PLUGIN_MAP = {
         "UIConfigPlugin": True,
         "WantedPlugin": True,
     },
-    # Can't implement Setup Game for MayWeekUtilitiesPlugin at the moment because config options depend on whether
-    # teams are enabled or not, and doing a partial implementation would mislead users.
-    # "May Week": {
-    #     "CompetencyPlugin":False,
-    #     "LocalBackupPlugin": True,
-    #     "MafiaPlugin": False,
-    #     "MayWeekUtilitiesPlugin": True,
-    #     "PageGeneratorPlugin": True,  # needed to be able to hide events
-    #     "CityWatchPlugin": False,
-    #     "RandomGamePlugin": False,
-    #     "ScoringPlugin": False,
-    #     "TargetingPlugin": False,
-    #     "UIConfigPlugin": True,
-    #     "WantedPlugin": True,
-    # }
+    "May Week": {
+        "CompetencyPlugin":False,
+        "LocalBackupPlugin": True,
+        "MafiaPlugin": False,
+        "MayWeekUtilitiesPlugin": True,
+        "PageGeneratorPlugin": True,  # needed to be able to hide events
+        "CityWatchPlugin": False,
+        "RandomGamePlugin": False,
+        "ScoringPlugin": False,
+        "TargetingPlugin": False,
+        "UIConfigPlugin": True,
+        "WantedPlugin": True,
+    }
 }
 BOUNTY_PLUGINS = ("BountyNewsPlugin", "BountyPlugin")
 
@@ -1092,7 +1090,8 @@ class CorePlugin(AbstractPlugin):
             Label("AU2 has two different plugins for setting bounties."),
             Label("'BountyNewsPlugin' is the allows you to mark certain events as bounties, "
                   "causing them to be rendered on the page bounty-news.html. See May Week 2025 in the archive for an "
-                  "example."),
+                  "example. (Note however that BountyNewsPlugin currently has some issues when used in May Week)."),
+            # ^ the issues are addressed by https://github.com/jsyiek/AU2/pull/178 which is yet to be merged...
             Label("'BountyPlugin' on the other hand displays bounties in a table, on the page bounties.html. "
                   "See Lent 2025 in the archive for an example."),
             SelectorList(

--- a/AU2/plugins/custom_plugins/CityWatchPlugin.py
+++ b/AU2/plugins/custom_plugins/CityWatchPlugin.py
@@ -279,12 +279,10 @@ class CityWatchPlugin(AbstractPlugin):
 
     def on_page_generate(self, htmlResponse, navbar_entries) -> List[HTMLComponent]:
         message = []
-        events = list(EVENTS_DATABASE.events.values())
-        events.sort(key=lambda event: event.datetime)
 
         city_watch_rank_manager = CityWatchRankManager(auto_ranking=self.gsdb_get("Auto Rank"), city_watch_kill_ranking=self.gsdb_get("City Watch Kills Rankup"))
         death_manager = DeathManager()
-        for e in events:
+        for e in EVENTS_DATABASE.events_chronologically():
             city_watch_rank_manager.add_event(e)
             death_manager.add_event(e)
 

--- a/AU2/plugins/custom_plugins/CompetencyPlugin.py
+++ b/AU2/plugins/custom_plugins/CompetencyPlugin.py
@@ -107,7 +107,7 @@ def get_active_players(death_manager: DeathManager) -> Set[str]:
     """
     active_players = []
 
-    for e in sorted(list(EVENTS_DATABASE.events.values()), key=lambda event: event.datetime):
+    for e in EVENTS_DATABASE.events_chronologically():
         death_manager.add_event(e)
         for killer, _ in e.kills:
             active_players.append(killer)
@@ -120,8 +120,6 @@ def get_player_infos(from_date=get_now_dt()) -> Dict[str, PlayerInfo]:
     """
     Returns a list of calculated player informations (see struct above)
     """
-    events = list(EVENTS_DATABASE.events.values())
-    events.sort(key=lambda event: event.datetime)
     start_datetime: datetime.datetime = get_game_start()
 
     competency_manager = CompetencyManager(start_datetime)
@@ -130,7 +128,7 @@ def get_player_infos(from_date=get_now_dt()) -> Dict[str, PlayerInfo]:
     # populates the death manager
     active_players = get_active_players(death_manager)
 
-    for e in events:
+    for e in EVENTS_DATABASE.events_chronologically():
         competency_manager.add_event(e)
 
     infos = {}
@@ -377,12 +375,10 @@ class CompetencyPlugin(AbstractPlugin):
 
     def on_hook_respond(self, hook: str, htmlResponse, data) -> List[HTMLComponent]:
         if hook == "SRCFPlugin_email":
-            events = list(EVENTS_DATABASE.events.values())
-            events.sort(key=lambda event: event.datetime)
 
             competency_manager = CompetencyManager(get_game_start())
             death_manager = DeathManager()
-            for e in events:
+            for e in EVENTS_DATABASE.events_chronologically():
                 competency_manager.add_event(e)
                 death_manager.add_event(e)
 
@@ -573,14 +569,12 @@ class CompetencyPlugin(AbstractPlugin):
         return [Table(deadlines, headings=headings)]
 
     def on_page_generate(self, htmlResponse, navbar_entries) -> List[HTMLComponent]:
-        events = list(EVENTS_DATABASE.events.values())
-        events.sort(key=lambda event: event.datetime)
         start_datetime: datetime.datetime = get_game_start()
 
         competency_manager = CompetencyManager(start_datetime)
         death_manager = DeathManager()
         limit = htmlResponse[self.html_ids["Datetime"]]
-        for e in events:
+        for e in EVENTS_DATABASE.events_chronologically():
             if e.datetime > limit:
                 break
             competency_manager.add_event(e)

--- a/AU2/plugins/custom_plugins/MayWeekUtilitiesPlugin.py
+++ b/AU2/plugins/custom_plugins/MayWeekUtilitiesPlugin.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 import dataclasses
+import datetime
 import functools
 from typing import DefaultDict, Dict, List, Optional, Sequence, Set
 
@@ -40,9 +41,13 @@ HEX_COLS = [
 CREW_COLOR_TEMPLATE = 'style="background-color:{HEX}"'
 TEAM_ENTRY_TEMPLATE = "<td {CREW_COLOR}>{TEAM}</td>"
 TEAM_HDR_TEMPLATE = "<th>{TEAM_STR}</th>"
+SINGLE_SCORE_ENTRY_TEMPLATE = "<td {CREW_COLOR}>{POINTS}</td>"
+SPLIT_SCORE_ENTRY_TEMPLATE = "<td {CREW_COLOR}>{TEMP_POINTS}</td><td {CREW_COLOR}>{PERM_POINTS}</td>" + SINGLE_SCORE_ENTRY_TEMPLATE
+SINGLE_SCORE_HDR_TEMPLATE = "<th>{POINTS_STR}</th>"
+SPLIT_SCORE_HDR_TEMPLATE = "<th>{TEMP_PTS_STR}</th><th>{PERM_PTS_STR}</th>" + SINGLE_SCORE_HDR_TEMPLATE
 PLAYER_ROW_TEMPLATE = "<tr><td>{REAL_NAME}</td><td>{PLAYER_TYPE}</td><td>{ADDRESS}</td><td>{COLLEGE}</td><td>{WATER_STATUS}</td><td>{NOTES}</td></tr>"
 PSEUDONYM_ROW_TEMPLATE = ("<tr><td {CREW_COLOR}>{PSEUDONYM}</td>"
-                         "<td {CREW_COLOR}>{POINTS}</td>"
+                         "{POINTS_ENTRY}"
                          "<td {CREW_COLOR}>{MULTIPLIER}</td>"
                          "{TEAM_ENTRY}</tr>")
 
@@ -132,6 +137,7 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
         self.cosmetics = [
             "Multiplier",
             "Teams",
+            "Points",
             "Temporary Points",
             "Permanent Points",
         ]
@@ -196,8 +202,8 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
         for p in self.scoring_parameters:
             self.ps_defaults[p.name] = p.default_value
 
-        self.printable_gain_formula = "Points gained from kills: ((V*b + B)*t + T)*m + M"
-        self.printable_loss_formula = "Points lost from death: -V*d - D"
+        self.printable_gain_formula = "(Temporary) Points gained from kills: ((V*b + B)*t + T)*m + M"
+        self.printable_loss_formula = "(Temporary) Points lost from death: -V*d - D"
 
         self.exports = [
             Export(
@@ -229,9 +235,9 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
             ),
             ConfigExport(
                 identifier="may_week_config_temp_points",
-                display_name="May Week -> Configure Temporary Points",
-                ask=self.ask_config_temp_points,
-                answer=self.answer_config_temp_points,
+                display_name="May Week -> Configure Permanent Points",
+                ask=self.ask_config_perm_points,
+                answer=self.answer_config_perm_points,
             ),
             ConfigExport(
                 identifier="may_week_cosmetics",
@@ -319,7 +325,7 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
             Label("Team multiplier sharing is now: " + "enabled" if enabled else "disabled")
         ]
 
-    def ask_config_temp_points(self):
+    def ask_config_perm_points(self):
         # TODO: would like to have this in some kind of conditional metacomponent,
         #       where enable/disable split asked first, and only if enable ask about other params!
         #       would be trivial with the refactoring in #164. Maybe do anyway?
@@ -357,7 +363,7 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
             ),
         ]
 
-    def answer_config_temp_points(self, html_response):
+    def answer_config_perm_points(self, html_response):
         investment_pct = html_response[self.html_ids["Investment %"]]
 
         if investment_pct < 0 or investment_pct > 100:
@@ -477,10 +483,13 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
     def render_assassin_summary(self, assassin: Assassin) -> List[AttributePairTableRow]:
         team_str = self.get_cosmetic_name("Teams").capitalize()
         multiplier_str = self.get_cosmetic_name("Multiplier").lower()
+        temp_score_str = self.get_cosmetic_name("Temporary Points")
+        perm_score_str = self.get_cosmetic_name("Permanent Points")
+        split_scores = bool(self.gsdb_get("Investment %"))
         teams_enabled = self.gsdb_get("Enable Teams?", False)
         team_names = self.gsdb_get("Team Names", self.ps_defaults["Team Names"])
         team_manager = self.TeamManager()
-        scores = self.calculate_scores(team_manager=team_manager)
+        scores, perm_scores = self.calculate_scores(team_manager=team_manager)
         multiplier_owners = self.get_multiplier_owners()
         multiplier_beneficiaries = self.get_multiplier_beneficiaries(multiplier_owners, team_manager)
 
@@ -488,7 +497,8 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
         team_name = team_names[team] if team is not None else "(Individual)"
 
         return [
-            ("Score", scores[assassin.identifier]),
+            (temp_score_str, scores[assassin.identifier]),
+            *((perm_score_str, perm_scores[assassin.identifier]) for _ in range(split_scores)),
             # will render as plural, but eh
             *((team_str, team_name) for _ in range(teams_enabled)),
             (f"Has {multiplier_str}", "Y" if assassin.identifier in multiplier_owners else "N"),
@@ -526,7 +536,7 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
         return response
 
     def get_cosmetic_name(self, name: str) -> str:
-        return self.gsdb_get(name, name.lower())
+        return self.gsdb_get(name, name)
 
     def get_multiplier_owners(self, before_event: int = float("inf")) -> List[str]:
         owners = set()
@@ -665,7 +675,7 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
             self.eps_set(e, "Team Changes", html_response[self.html_ids["Team Changes"]])
         return [Label("[MAY WEEK] Success!")]
 
-    def calculate_scores(self, before_event: int = float("inf"), team_manager = None) -> Dict[str, float]:
+    def calculate_scores(self, before_event: int = float("inf"), team_manager = None) -> (Dict[str, float], Dict[str, float]):
         d = self.gsdb_get("death_penalty_pct", 0) / 100
         D = self.gsdb_get("death_penalty_fixed", 0)
         b = self.gsdb_get("kill_bonus_pct", 0) / 100
@@ -676,6 +686,7 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
         M = self.gsdb_get("multiplier_bonus_fixed", 0)
         Sc = self.gsdb_get("starting_score_casual", 0)
         Sf = self.gsdb_get("starting_score_full", 0)
+        invest_prop = self.gsdb_get("Investment %") / 100
 
         # passing a team manager allows us to extract team information after this function runs
         team_manager = team_manager or self.TeamManager()
@@ -684,9 +695,29 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
             include_hidden = lambda _: True  # probably not necessary in May Week (since no resurrection as city watch),
                                              # but just in case...
         )}
+
+        perm_scores: Dict[str, float] = defaultdict(lambda: 0)
+
+        previous_kills: Dict[str, Set[str]] = defaultdict(set)  # map { identifier: set of victims }
+        day_investers: Dict[datetime.date, Set[str]] = defaultdict(set) # map { day: set of players who invested}
+
         multiplier_owners = set()
         teams_enabled = self.gsdb_get("Enable Teams?", False)
         team_multiplier_sharing_enabled = teams_enabled and self.gsdb_get("Share Multipliers?", self.ps_defaults["Share Multipliers?"])
+        invest_first = self.gsdb_get("Invest first?")
+
+        if invest_prop:
+            def do_investments(e: Event):
+                for (killer, victim) in e.kills:
+                    date = e.datetime.date()
+                    if killer not in day_investers[date] and victim not in previous_kills[killer]:
+                        to_invest = scores[killer] * invest_prop
+                        scores[killer] -= to_invest
+                        perm_scores[killer] += to_invest
+                        day_investers[date].add(killer)
+        else:
+            def do_investments(e: Event):
+                pass
 
         # unfortunately events have to processed in order of secret id (i.e. in the order they were created)
         # so that the multiplier transfer interface in Event -> Create / Event -> Update  works correctly...
@@ -701,10 +732,14 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
             member_to_team = team_manager.member_to_team
             team_to_members = team_manager.team_to_member_map()
 
+            if invest_first:
+                do_investments(e)
+
             # updates happen atomically, so we calculate them as a batch and then add them back in
             point_deltas = {player: bs_allotment for (player, bs_allotment) in bs_points}
 
             for (killer, victim) in e.kills:
+                previous_kills[killer].add(victim)
                 is_as_team = teams_enabled and (killer, victim) in kills_made_as_team
                 is_with_multiplier = killer in multiplier_owners
                 if team_multiplier_sharing_enabled and not is_with_multiplier:
@@ -729,6 +764,9 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
                 # (specifically, if killing a player with negative points would lose you points)
                 scores[player] = max(0, scores[player] + point_deltas[player])
 
+            if not invest_first:
+                do_investments(e)
+
             # work out any multiplier transfers
             for (loser, gainer) in e.pluginState.get(self.identifier, {}).get(self.plugin_state["Multiplier Transfers"], []):
                 if loser is not None and loser in multiplier_owners:
@@ -736,7 +774,7 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
                 if gainer is not None:
                     multiplier_owners.add(gainer)
 
-        return scores
+        return scores, perm_scores
 
     def on_page_generate(self, htmlResponse, navbar_entries) -> List[HTMLComponent]:
         """
@@ -748,14 +786,15 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
         The may week news page collates all the events onto a single page (rather than paginating like
         PageGeneratorPlugin) and applies May Week name colouring (i.e. crews share a colour, don't colour city watch
         (casual players) differently, don't colour dead players differently outside the event in which they died, don't
-        colourincos).
+        colour incos).
         """
 
         # player info page
         team_manager = self.TeamManager()
-        scores = self.calculate_scores(team_manager=team_manager)
+        temp_scores, perm_scores = self.calculate_scores(team_manager=team_manager)
         multiplier_owners = set(self.get_multiplier_owners())
         teams_enabled = self.gsdb_get("Enable Teams?", False)
+        split_scores = bool(self.gsdb_get("Investment %"))
         member_to_team = team_manager.member_to_team
         team_to_members = team_manager.team_to_member_map()
         team_names = self.gsdb_get("Team Names", self.ps_defaults["Team Names"])
@@ -765,25 +804,35 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
         for (i, team) in enumerate(team_to_members):
             team_to_hex_col[team] = HEX_COLS[i % len(HEX_COLS)]
 
-        # discard hidden players from scores -- in case a dummy casual player is added to represent a civilian
-        for hidden_id in ASSASSINS_DATABASE.get_identifiers(include = lambda _: False,
-                                                            include_hidden = lambda _: True):
-            scores.pop(hidden_id, None)
+        # total score is sum of temp and perm scores
+        scores = {
+            identifier: temp_scores[identifier] + perm_scores[identifier]
+            for identifier in ASSASSINS_DATABASE.get_identifiers(include_hidden = False)
+        }
 
         pseudonym_rows = []
         for (score, a_id) in sorted(((v, k) for (k, v) in scores.items()), reverse=True):
-            # PSEUDONYM_ROW_TEMPLATE = "<tr {CREW_COLOR}><td>{RANK}</td><td>{PSEUDONYM}</td><td>{POINTS}</td><td>{MULTIPLIER}</td></tr>{TEAM_ENTRY}"
             team_id = member_to_team[a_id]
             crew_color = (CREW_COLOR_TEMPLATE.format(HEX=team_to_hex_col[team_id]) if team_id is not None else "")
             team_entry = (TEAM_ENTRY_TEMPLATE.format(TEAM=team_names[team_id], CREW_COLOR=crew_color) if team_id is not None else "")
+            points_entry = SPLIT_SCORE_ENTRY_TEMPLATE.format(
+                CREW_COLOR=crew_color,
+                TEMP_POINTS=temp_scores[a_id],
+                PERM_POINTS=perm_scores[a_id],
+                POINTS=score
+            ) if split_scores else SINGLE_SCORE_ENTRY_TEMPLATE.format(
+                CREW_COLOR=crew_color,
+                POINTS=score
+            )
+
             assassin = ASSASSINS_DATABASE.get(a_id)
             pseudonym_rows.append(
                 PSEUDONYM_ROW_TEMPLATE.format(
                     CREW_COLOR=crew_color,
                     PSEUDONYM=assassin.all_pseudonyms(),
-                    POINTS=score,
+                    POINTS_ENTRY = points_entry,
                     MULTIPLIER="Y" if a_id in multiplier_beneficiaries else "",
-                    TEAM_ENTRY=team_entry
+                    TEAM_ENTRY=team_entry,
                 )
             )
 
@@ -810,8 +859,13 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
                 YEAR = get_now_dt().year,
                 MULTIPLIER_STR = self.gsdb_get("Multiplier", "Multiplier"),
                 TEAM_COLUMN_HDR = TEAM_HDR_TEMPLATE.format(
-                    TEAM_STR = self.get_cosmetic_name("Teams") if teams_enabled else ""
-                )
+                    TEAM_STR = self.get_cosmetic_name("Teams")
+                ) if teams_enabled else "",
+                POINTS_HDR = SPLIT_SCORE_HDR_TEMPLATE.format(
+                    TEMP_PTS_STR = self.get_cosmetic_name("Temporary Points"),
+                    PERM_PTS_STR = self.get_cosmetic_name("Permanent Points"),
+                    POINTS_STR = self.get_cosmetic_name("Points"),
+                ) if split_scores else SINGLE_SCORE_HDR_TEMPLATE.format(POINTS_STR = self.get_cosmetic_name("Points"))
             ))
 
         # may week news page

--- a/AU2/plugins/custom_plugins/MayWeekUtilitiesPlugin.py
+++ b/AU2/plugins/custom_plugins/MayWeekUtilitiesPlugin.py
@@ -758,13 +758,14 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
 
         if split_scores:
             def do_investments(e: Event):
+                date = e.datetime.date()
                 for (killer, victim) in e.kills:
-                    date = e.datetime.date()
                     if killer not in day_investers[date] and victim not in previous_kills[killer]:
                         to_invest = temp_scores[killer] * invest_prop
                         temp_scores[killer] -= to_invest
                         perm_scores[killer] += to_invest
                         day_investers[date].add(killer)
+
         else:
             def do_investments(e: Event):
                 pass

--- a/AU2/plugins/custom_plugins/MayWeekUtilitiesPlugin.py
+++ b/AU2/plugins/custom_plugins/MayWeekUtilitiesPlugin.py
@@ -42,8 +42,6 @@ HEX_COLS = [
 CREW_COLOR_TEMPLATE = 'style="background-color:{HEX}"'
 ENTRY_TEMPLATE = "<td {CREW_COLOR}>{VALUE}</td>"
 HDR_TEMPLATE = "<th>{HEADING}</th>"
-SPLIT_SCORE_ENTRY_TEMPLATE = "<td {CREW_COLOR}>{TEMP_POINTS}</td><td {CREW_COLOR}>{PERM_POINTS}</td><td {CREW_COLOR}>{POINTS}</td>"
-SPLIT_SCORE_HDR_TEMPLATE = "<th>{TEMP_PTS_STR}</th><th>{PERM_PTS_STR}</th><th>{POINTS_STR}</th>"
 PLAYER_ROW_TEMPLATE = "<tr><td>{REAL_NAME}</td><td>{PLAYER_TYPE}</td><td>{ADDRESS}</td><td>{COLLEGE}</td><td>{WATER_STATUS}</td><td>{NOTES}</td></tr>"
 PSEUDONYM_ROW_TEMPLATE = ("<tr><td {CREW_COLOR}>{PSEUDONYM}</td>"
                          "{POINTS_ENTRY}"
@@ -89,15 +87,27 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
     def __init__(self):
         super().__init__(type(self).__name__)
 
+        self.gimmick_names = {
+            "teams": "Teams",
+            "multipliers": "Multipliers",
+            "investment": "Temporary/Permanent Points",
+        }
+
+        self.point_type_names = {
+            "temp_points": "Temporary Points",
+            "perm_points": "Permanent Points",
+            "total_points": "Total Points",
+        }
+
         self.html_ids = {
             "Team Names": self.identifier + "_team_names",
             "Gimmicks": self.identifier + "_gimmicks",
             "Share Multipliers?": self.identifier + "_share_multipliers",
             "Investment %": self.identifier + "_investment_pct",
             "Invest first?": self.identifier + "_invest_first",
-            "Temp Points Floor": self.identifier + "_temp_pts_floor",
             "Deplete Permanent Points?": self.identifier + "_deplete_perm_pts",
             "Perm Points Floor": self.identifier + "_perm_pts_floor",
+            "Visible Points": self.identifier + "_visible_points",
             "Assassins": self.identifier + "_assassins",
             "Team ID": self.identifier + "_team_id",
             "Team Changes": self.identifier + "_team_changes",
@@ -113,9 +123,9 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
             "Share Multipliers?": "share_multipliers",
             "Investment %": "investment_pct",
             "Invest first?": "invest_first",
-            "Temp Points Floor": "temp_pts_floor",
             "Deplete Permanent Points?": "deplete_perm_pts",
             "Perm Points Floor": "perm_pts_floor",
+            "Visible Points": "visible_points",
             "Team Members": "team_members",
             "Team Changes": "team_changes",
             "Multiplier Transfers": "multiplier_transfers",
@@ -129,9 +139,9 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
             "Share Multipliers?": False,
             "Investment %": 0,
             "Invest first?": True,
-            "Temp Points Floor": 0,
             "Deplete Permanent Points?": True,
             "Perm Points Floor": None,
+            "Visible Points": list(self.point_type_names)
         }
 
         self.cosmetics = [
@@ -140,15 +150,10 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
             "Points",
             "Temporary Points",
             "Permanent Points",
+            "Total Points",
         ]
         self.html_ids.update({k: self.identifier + "_" + k.lower() for k in self.cosmetics})
         self.plugin_state.update({k: k.lower() for k in self.cosmetics})
-
-        self.gimmick_names = {
-            "teams": "Teams",
-            "multipliers": "Multipliers",
-            "investment": "Temporary/Permanent Points",
-        }
 
         self.scoring_parameters = [
             ScoringParameter(
@@ -223,7 +228,7 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
         self.config_exports = [
             ConfigExport(
                 identifier="may_week_set_gimmicks",
-                display_name="May Week -> Enable/disable Gimmicks",
+                display_name="May Week -> Enable/disable MW gimmicks",
                 ask=self.ask_set_gimmicks,
                 answer=self.answer_set_gimmicks
             ),
@@ -240,7 +245,7 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
                 answer=self.answer_enable_multiplier_team_sharing
             ),
             ConfigExport(
-                identifier="may_week_config_temp_points",
+                identifier="may_week_config_perm_points",
                 display_name="May Week -> Configure Permanent Points",
                 ask=self.ask_config_perm_points,
                 answer=self.answer_config_perm_points,
@@ -343,19 +348,12 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
             ),
             # TODO: consider whether InputWithDropdown better?
             Checkbox(
-                title="Invest Temporary Points BEFORE profiting from kills (and BS points)?",
+                title="Invest Temporary Points BEFORE players profit from kills (and BS points)?",
                 identifier=self.html_ids["Invest first?"],
                 checked=self.gsdb_get("Invest first?"),
             ),
-            FloatEntry(
-                title="Floor for Temporary Points (Temporary Points will not be allowed to decrease below this value; "
-                      "leave blank for no floor)",
-                identifier=self.html_ids["Temp Points Floor"],
-                default=self.gsdb_get("Temp Points Floor"),
-                optional=True,
-            ),
             Checkbox(
-                title="Transfer Permanent Points back to Temporary Points to keep the latter above the floor?",
+                title="Transfer Permanent Points back to Temporary Points if the latter falls below 0?",
                 identifier=self.html_ids["Deplete Permanent Points?"],
                 checked=self.gsdb_get("Deplete Permanent Points?"),
             ),
@@ -366,6 +364,13 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
                 default=self.gsdb_get("Perm Points Floor"),
                 optional=True,
             ),
+            # TODO: selectorlist for which points to show (out Temp Points, Perm Points, Total Points)
+            SelectorList(
+                title="Which types of points should be shown in the player list?",
+                identifier=self.html_ids["Visible Points"],
+                options=[(v, k) for k, v in self.point_type_names.items()],
+                defaults=self.gsdb_get("Visible Points"),
+            )
         ]
 
     def answer_config_perm_points(self, html_response):
@@ -375,18 +380,18 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
             return [Label(f"[ERROR] Cannot invest {investment_pct}% of temporary points!")]
 
         invest_first = html_response[self.html_ids["Invest first?"]]
-        temp_pts_floor = html_response[self.html_ids["Temp Points Floor"]]
         deplete_perm_pts = html_response[self.html_ids["Deplete Permanent Points?"]]
         perm_pts_floor = html_response[self.html_ids["Perm Points Floor"]]
+        visible_point_types = html_response[self.html_ids["Visible Points"]]
 
         self.gsdb_set("Investment %", investment_pct)
         self.gsdb_set("Invest first?", invest_first)
-        self.gsdb_set("Temp Points Floor", temp_pts_floor)
         self.gsdb_set("Deplete Permanent Points?", deplete_perm_pts)
         self.gsdb_set("Perm Points Floor", perm_pts_floor)
+        self.gsdb_set("Visible Points", visible_point_types)
 
         # TODO: more informative message
-        return [Label("[MAY WEEK] Configured temporary points.")]
+        return [Label("[MAY WEEK] Configured permanent points.")]
 
     def ask_name_teams(self):
         existing_ranks: List[str] = self.gsdb_get("Team Names", self.ps_defaults["Team Names"])
@@ -435,17 +440,20 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
                 title=param.description,
                 default=self.gsdb_get(param.name, param.default_value),
                 identifier=self.html_ids[param.name]
-            ) for param in self.scoring_parameters)
+            ) for param in self.scoring_parameters),
         ]
 
     def answer_set_scoring_params(self, html_response):
         for param in self.scoring_parameters:
             self.gsdb_set(param.name, html_response[self.html_ids[param.name]])
 
+        points_floor = html_response[self.html_ids["Points Floor"]]
+        self.gsdb_set("Points Floor", points_floor)
+
         return [
             Label(title=f"Parameter {param.name} set to {html_response[self.html_ids[param.name]]}")
             for param in self.scoring_parameters
-        ]
+        ] + [Label(f"Points floor set to {points_floor}")]
 
     def ask_teams_summary(self) -> List[HTMLComponent]:
         return [
@@ -739,6 +747,8 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
         )
         split_scores = gimmick_map.get("investment")
         invest_first = self.gsdb_get("Invest first?")
+        deplete_perm_pts = self.gsdb_get("Deplete Permanent Points?")
+        perm_pts_floor = self.gsdb_get("Perm Points Floor")
 
         if split_scores:
             def do_investments(e: Event):
@@ -794,9 +804,15 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
 
             # resolve deltas once all worked out
             for player in point_deltas:
-                # use max or else you can LOSE points by killing someone!
-                # (specifically, if killing a player with negative points would lose you points)
-                temp_scores[player] = max(0, temp_scores[player] + point_deltas[player])
+                # keep temp points >= 0, as killing a player with negative points would lose you points!
+                new_score = temp_scores[player] + point_deltas[player]
+                if new_score < 0:
+                    if deplete_perm_pts:
+                        new_perm_score = perm_scores[player] + new_score
+                        if perm_pts_floor is not None:
+                            perm_scores[player] = max(new_perm_score, perm_pts_floor)
+                    new_score = 0
+                temp_scores[player] = new_score
 
             if not invest_first:
                 do_investments(e)
@@ -829,6 +845,7 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
         teams_enabled = gimmick_map.get("teams", False)
         multipliers_enabled = gimmick_map.get("multipliers", False)
         split_scores = gimmick_map.get("investment", False)
+        visible_point_types = self.gsdb_get("Visible Points")
 
         team_manager = self.TeamManager()
         temp_scores, perm_scores = self.calculate_scores(team_manager=team_manager)
@@ -860,11 +877,18 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
                 VALUE="Y" if a_id in multiplier_beneficiaries else "",
                 CREW_COLOR=crew_color
             ) if multipliers_enabled else ""
-            points_entry = SPLIT_SCORE_ENTRY_TEMPLATE.format(
-                CREW_COLOR=crew_color,
-                TEMP_POINTS=temp_scores[a_id],
-                PERM_POINTS=perm_scores[a_id],
-                POINTS=score
+
+            # if using temporary/permanent points, user can configure which of the three headings they want rendered in
+            # the player list.  e.g. in MW2024, only total + permanent points were shown, and not temporary points on
+            # their own
+            score_values= {
+                "temp_points": temp_scores[a_id],
+                "perm_points": perm_scores[a_id],
+                "total_points": score
+            }
+            points_entry = "".join(
+                ENTRY_TEMPLATE.format(CREW_COLOR=crew_color, VALUE=score_values[score_type])
+                for score_type in visible_point_types
             ) if split_scores else ENTRY_TEMPLATE.format(CREW_COLOR=crew_color, VALUE=score)
 
             assassin = ASSASSINS_DATABASE.get(a_id)
@@ -905,10 +929,9 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
                 TEAM_COLUMN_HDR = HDR_TEMPLATE.format(
                     HEADING = self.get_cosmetic_name("Teams")
                 ) if teams_enabled else "",
-                POINTS_HDR = SPLIT_SCORE_HDR_TEMPLATE.format(
-                    TEMP_PTS_STR = self.get_cosmetic_name("Temporary Points"),
-                    PERM_PTS_STR = self.get_cosmetic_name("Permanent Points"),
-                    POINTS_STR = self.get_cosmetic_name("Points"),
+                POINTS_HDR = "".join(
+                    HDR_TEMPLATE.format(HEADING = self.get_cosmetic_name(self.point_type_names[point_type]))
+                    for point_type in visible_point_types
                 ) if split_scores else HDR_TEMPLATE.format(HEADING = self.get_cosmetic_name("Points"))
             ))
 

--- a/AU2/plugins/custom_plugins/MayWeekUtilitiesPlugin.py
+++ b/AU2/plugins/custom_plugins/MayWeekUtilitiesPlugin.py
@@ -114,7 +114,8 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
             "Multiplier Transfer": self.identifier + "_multiplier_transfer",
             "Kills as Team": self.identifier + "_kills_as_team",
             "BS Points": self.identifier + "_bs_points",
-            "Event Secret ID": self.identifier + "_event_secret_id"
+            "Event Secret ID": self.identifier + "_event_secret_id",
+            "Event": self.identifier + "_event_id",
         }
 
         self.plugin_state = {
@@ -275,10 +276,8 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
                 TeamManager_self.member_to_team.update(team_memb_changes)
                 TeamManager_self.team_to_member_map.cache_clear()
 
-            def process_events_until(self, before_event: int = float("Inf")) -> "TeamManager":
-                for e in EVENTS_DATABASE.events.values():
-                    if int(e._Event__secret_id) >= before_event:
-                        continue
+            def process_events_until(self, last: Optional[Event] = None) -> "TeamManager":
+                for e in EVENTS_DATABASE.events_chronologically(last=last):
                     self.add_event(e)
                 return self
 
@@ -459,28 +458,25 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
 
     def ask_teams_summary(self) -> List[HTMLComponent]:
         return [
-            # TODO: PR #143 might be able to solve this
-            Label(f"Note: due to technical limitations, {self.identifier} processes events in the order in which they "
-                  f"were added, not in order of the datetimes assigned to each event."),
-            InputWithDropDown(identifier=self.html_ids["Event Secret ID"],
+            InputWithDropDown(identifier=self.html_ids["Event"],
                               title="Select the event AFTER which to view team status",
                               options=[
-                                  (f"({e._Event__secret_id}) "
-                                   f"[{e.datetime.strftime('%Y-%m-%d %H:%M %p')}] {e.headline[0:25].rstrip()}",
-                                   e._Event__secret_id)
-                                  for e in reversed(EVENTS_DATABASE.events.values())
+                                  (e.text_display(),
+                                   e.identifier)
+                                  for e in reversed(EVENTS_DATABASE.events_chronologically())
                               ])
         ]
 
-    def answer_teams_summary(self, htmlResponse) -> List[HTMLComponent]:
+    def answer_teams_summary(self, html_response) -> List[HTMLComponent]:
         teams_str = self.get_cosmetic_name("Teams").capitalize()
         multiplier_str = self.get_cosmetic_name("Multiplier").capitalize()
-        team_manager = self.TeamManager().process_events_until(before_event=int(
-            htmlResponse[self.html_ids["Event Secret ID"]]) + 1
-        )
+
+        event = EVENTS_DATABASE.get(html_response[self.html_ids["Event"]])
+
+        team_manager = self.TeamManager().process_events_until(event)
         team_to_members = team_manager.team_to_member_map()
         team_names = self.gsdb_get("Team Names", self.ps_defaults["Team Names"])
-        multiplier_owners = self.get_multiplier_owners()
+        multiplier_owners = self.get_multiplier_owners(after=event)
         rows = []
         for team_id, team_name in sorted(enumerate(team_names), key=lambda x: x[1]):
             members = team_to_members[team_id]
@@ -563,11 +559,9 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
     def get_cosmetic_name(self, name: str) -> str:
         return self.gsdb_get(name, name)
 
-    def get_multiplier_owners(self, before_event: int = float("inf")) -> List[str]:
+    def get_multiplier_owners(self, after: Optional[Event] = None) -> List[str]:
         owners = set()
-        for event in EVENTS_DATABASE.events.values():
-            if int(event._Event__secret_id) >= before_event:
-                continue
+        for event in EVENTS_DATABASE.events_chronologically(last=after):
             key = self.plugin_state["Multiplier Transfers"]
             for (loser, gainer) in event.pluginState.get(self.identifier, {}).get(key, []):
                 if loser is not None and loser in owners:
@@ -611,14 +605,19 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
                         identifier=self.html_ids["BS Points"],
                         title="[MAY WEEK] Want to award any BS points?",
                     ),
-                    Label(f"[MAY WEEK] WARNING! Changing this will not play nicely if the {multiplier_str} has already "
-                          "transferred again after this!"),
-                    *(AssassinDependentTransferEntry(
-                        assassins_list_identifier="CorePlugin_assassin_pseudonym",
-                        identifier=self.html_ids["Multiplier Transfer"],
-                        owners=self.get_multiplier_owners(),
-                        title=f"[MAY WEEK] Any {multiplier_str} transfers? (None -> A adds a new {multiplier_str}, A -> None deletes it)"
-                    ) for _ in range(multipliers_enabled)),
+                    *(
+                        (
+                            Label(f"[MAY WEEK] WARNING! Changing this will not play nicely if the {multiplier_str} has "
+                                  f"already transferred again after this!"),
+                            AssassinDependentTransferEntry(
+                                assassins_list_identifier="CorePlugin_assassin_pseudonym",
+                                identifier=self.html_ids["Multiplier Transfer"],
+                                owners=[],  # cannot determine for now...
+                                title=f"[MAY WEEK] Any {multiplier_str} transfers?",
+                                transfer_item_name=multiplier_str,
+                            ),
+                        ) if multipliers_enabled else ()
+                    ),
 
                     *(AssassinDependentInputWithDropDown(
                         pseudonym_list_identifier="CorePlugin_assassin_pseudonym",
@@ -642,7 +641,7 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
         ]
 
     def on_event_create(self, e: Event, html_response) -> List[HTMLComponent]:
-        if self.html_ids["Multiplier Transfers"] in html_response:
+        if self.html_ids["Multiplier Transfer"] in html_response:
             self.eps_set(e, "Multiplier Transfers", html_response[self.html_ids["Multiplier Transfer"]])
         self.eps_set(e, "BS Points",  html_response[self.html_ids["BS Points"]])
         if self.html_ids["Kills as Team"] in html_response:
@@ -668,15 +667,20 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
                         title="Want to award any BS points?",
                         default=self.eps_get(e, "BS Points", {})
                     ),
-                    Label(f"[MAY WEEK] WARNING! Changing this will not play nicely if the {multiplier_str} has already "
-                          "transferred again after this!"),
-                    *(AssassinDependentTransferEntry(
-                        assassins_list_identifier="CorePlugin_assassin_pseudonym",
-                        identifier=self.html_ids["Multiplier Transfer"],
-                        owners=self.get_multiplier_owners(before_event=int(e._Event__secret_id)),
-                        title=f"[MAY WEEK] Any {multiplier_str} transfers?",
-                        default=self.eps_get(e, "Multiplier Transfers", [])
-                    ) for _ in range(multipliers_enabled)),
+                    *(
+                        (
+                            Label(f"[MAY WEEK] WARNING! Changing this will not play nicely if the {multiplier_str} has "
+                                  f"already transferred again after this!"),
+                            AssassinDependentTransferEntry(
+                                assassins_list_identifier="CorePlugin_assassin_pseudonym",
+                                identifier=self.html_ids["Multiplier Transfer"],
+                                owners=[], # cannot determine for now...
+                                title=f"[MAY WEEK] Any {multiplier_str} transfers?",
+                                default=self.eps_get(e, "Multiplier Transfers", []),
+                                transfer_item_name=multiplier_str,
+                            ),
+                        ) if multipliers_enabled else ()
+                    ),
                     *(AssassinDependentInputWithDropDown(
                         pseudonym_list_identifier="CorePlugin_assassin_pseudonym",
                         identifier=self.html_ids["Team Changes"],
@@ -700,7 +704,7 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
         ]
 
     def on_event_update(self, e: Event, html_response) -> List[HTMLComponent]:
-        if self.html_ids["Multiplier Transfers"] in html_response:
+        if self.html_ids["Multiplier Transfer"] in html_response:
             self.eps_set(e, "Multiplier Transfers", html_response[self.html_ids["Multiplier Transfer"]])
         self.eps_set(e, "BS Points",  html_response[self.html_ids["BS Points"]])
         if self.html_ids["Kills as Team"] in html_response:
@@ -709,7 +713,7 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
             self.eps_set(e, "Team Changes", html_response[self.html_ids["Team Changes"]])
         return [Label("[MAY WEEK] Success!")]
 
-    def calculate_scores(self, before_event: int = float("inf"), team_manager = None) -> (Dict[str, float], Dict[str, float]):
+    def calculate_scores(self, team_manager = None) -> (Dict[str, float], Dict[str, float]):
         """
         Returns:
             (temporary points, permanent points)
@@ -765,11 +769,7 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
             def do_investments(e: Event):
                 pass
 
-        # unfortunately events have to processed in order of secret id (i.e. in the order they were created)
-        # so that the multiplier transfer interface in Event -> Create / Event -> Update  works correctly...
-        for e in EVENTS_DATABASE.events.values():
-            if int(e._Event__secret_id) > before_event:
-                continue
+        for e in EVENTS_DATABASE.events_chronologically():
             kills_made_as_team = self.eps_get(e, "Kills as Team", [])
             bs_points = self.eps_get(e, "BS Points", {}).items()
 
@@ -883,7 +883,7 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
             # if using temporary/permanent points, user can configure which of the three headings they want rendered in
             # the player list.  e.g. in MW2024, only total + permanent points were shown, and not temporary points on
             # their own
-            score_values= {
+            score_values = {
                 "temp_points": temp_scores[a_id],
                 "perm_points": perm_scores[a_id],
                 "total_points": score

--- a/AU2/plugins/custom_plugins/MayWeekUtilitiesPlugin.py
+++ b/AU2/plugins/custom_plugins/MayWeekUtilitiesPlugin.py
@@ -104,7 +104,6 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
             "Gimmicks": self.identifier + "_gimmicks",
             "Share Multipliers?": self.identifier + "_share_multipliers",
             "Investment %": self.identifier + "_investment_pct",
-            "Invest first?": self.identifier + "_invest_first",
             "Deplete Permanent Points?": self.identifier + "_deplete_perm_pts",
             "Perm Points Floor": self.identifier + "_perm_pts_floor",
             "Visible Points": self.identifier + "_visible_points",
@@ -347,12 +346,6 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
                 identifier=self.html_ids["Investment %"],
                 default=self.gsdb_get("Investment %"),
             ),
-            # TODO: consider whether InputWithDropdown better?
-            Checkbox(
-                title="Invest Temporary Points BEFORE players profit from kills (and BS points)?",
-                identifier=self.html_ids["Invest first?"],
-                checked=self.gsdb_get("Invest first?"),
-            ),
             Checkbox(
                 title="Transfer Permanent Points back to Temporary Points if the latter falls below 0?",
                 identifier=self.html_ids["Deplete Permanent Points?"],
@@ -365,7 +358,6 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
                 default=self.gsdb_get("Perm Points Floor"),
                 optional=True,
             ),
-            # TODO: selectorlist for which points to show (out Temp Points, Perm Points, Total Points)
             SelectorList(
                 title="Which types of points should be shown in the player list?",
                 identifier=self.html_ids["Visible Points"],
@@ -380,13 +372,11 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
         if investment_pct < 0 or investment_pct > 100:
             return [Label(f"[ERROR] Cannot invest {investment_pct}% of temporary points!")]
 
-        invest_first = html_response[self.html_ids["Invest first?"]]
         deplete_perm_pts = html_response[self.html_ids["Deplete Permanent Points?"]]
         perm_pts_floor = html_response[self.html_ids["Perm Points Floor"]]
         visible_point_types = html_response[self.html_ids["Visible Points"]]
 
         self.gsdb_set("Investment %", investment_pct)
-        self.gsdb_set("Invest first?", invest_first)
         self.gsdb_set("Deplete Permanent Points?", deplete_perm_pts)
         self.gsdb_set("Perm Points Floor", perm_pts_floor)
         self.gsdb_set("Visible Points", visible_point_types)
@@ -752,23 +742,8 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
                 and self.gsdb_get("Share Multipliers?", self.ps_defaults["Share Multipliers?"])
         )
         split_scores = gimmick_map.get("investment")
-        invest_first = self.gsdb_get("Invest first?")
         deplete_perm_pts = self.gsdb_get("Deplete Permanent Points?")
         perm_pts_floor = self.gsdb_get("Perm Points Floor")
-
-        if split_scores:
-            def do_investments(e: Event):
-                date = e.datetime.date()
-                for (killer, victim) in e.kills:
-                    if killer not in day_investers[date] and victim not in previous_kills[killer]:
-                        to_invest = temp_scores[killer] * invest_prop
-                        temp_scores[killer] -= to_invest
-                        perm_scores[killer] += to_invest
-                        day_investers[date].add(killer)
-
-        else:
-            def do_investments(e: Event):
-                pass
 
         for e in EVENTS_DATABASE.events_chronologically():
             kills_made_as_team = self.eps_get(e, "Kills as Team", [])
@@ -779,8 +754,14 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
             member_to_team = team_manager.member_to_team
             team_to_members = team_manager.team_to_member_map()
 
-            if invest_first:
-                do_investments(e)
+            if split_scores:
+                date = e.datetime.date()
+                for (killer, victim) in e.kills:
+                    if killer not in day_investers[date] and victim not in previous_kills[killer]:
+                        to_invest = temp_scores[killer] * invest_prop
+                        temp_scores[killer] -= to_invest
+                        perm_scores[killer] += to_invest
+                        day_investers[date].add(killer)
 
             # updates happen atomically, so we calculate them as a batch and then add them back in
             point_deltas = {player: bs_allotment for (player, bs_allotment) in bs_points}
@@ -817,9 +798,6 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
                         perm_scores[player] = new_perm_score
                     new_score = 0
                 temp_scores[player] = new_score
-
-            if not invest_first:
-                do_investments(e)
 
             # work out any multiplier transfers
             for (loser, gainer) in e.pluginState.get(self.identifier, {}).get(self.plugin_state["Multiplier Transfers"], []):

--- a/AU2/plugins/custom_plugins/MayWeekUtilitiesPlugin.py
+++ b/AU2/plugins/custom_plugins/MayWeekUtilitiesPlugin.py
@@ -227,6 +227,18 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
                 default_value=1,
                 description="M = Fixed bonus points awarded when kills are made with a multiplier"
             ),
+            ScoringParameter(
+                name="multiple_kill_penalty_pct",
+                default_value=100,
+                description="pk = % multiplier to apply to the points awarded to the killer (after bonuses) for each "
+                            "time the killer has killed the victim previously"
+            ),
+            ScoringParameter(
+                name="multiple_death_mitigation_pct",
+                default_value=100,
+                description="pv = % multiplier to apply to the points lost by the victim (after bonuses) for each "
+                            "time the killer has killed them previously"
+            ),
         ]
         self.html_ids.update({param.name: self.identifier + "_" + param.name.lower() for param in self.scoring_parameters})
         self.plugin_state.update({param.name: param.identifier() for param in self.scoring_parameters})
@@ -240,8 +252,10 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
             "Let I_w = 1 if the victim is Wanted, 0 otherwise.",
             "Let I_t = 1 if the kill was made as a team kill, 0 otherwise.",
             "Let I_m = 1 if the killer was benefiting from a Multiplier, 0 otherwise.",
-            "Then (temporary) points GAINED by the killer = (b*V + B) + I_w * (wb*V + Wb) + I_t * (t*V + T) + I_m * (m*V + M)",
-            "And (temporary) points LOST by the victim = (d*V + D) + I_w * (wd * V + Wd)",
+            "Let n be the number of times the killer has previously killed this victim.",
+            "Then (temporary) points GAINED by the killer = ((b*V + B) + I_w * (wb*V + Wb) + I_t * (t*V + T) + I_m * (m*V + M)) * (pk ** n)",
+            "And (temporary) points LOST by the victim = ((d*V + D) + I_w * (wd * V + Wd)) * (pv ** n)",
+            "(where ** denotes exponentiation).",
         )
 
         self.exports = [
@@ -748,7 +762,11 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
         M = self.gsdb_get("multiplier_bonus_fixed", 0)
         Sc = self.gsdb_get("starting_score_casual", 0)
         Sf = self.gsdb_get("starting_score_full", 0)
+
         invest_prop = self.gsdb_get("Investment %") / 100
+
+        pk = self.gsdb_get("multiple_kill_penalty_pct", 100) / 100
+        pv = self.gsdb_get("multiple_death_mitigation_pct", 100) / 100
 
         wanted_manager = WantedManager()
         wanted_manager.activated = True
@@ -763,7 +781,7 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
 
         perm_scores: Dict[str, float] = defaultdict(lambda: 0)
 
-        previous_kills: Dict[str, Set[str]] = defaultdict(set)  # map { identifier: set of victims }
+        previous_kills: Dict[str, Dict[str, int]] = defaultdict(lambda: defaultdict(lambda: 0))  # map { identifier: {victim: times killed}}
         day_investers: Dict[datetime.date, Set[str]] = defaultdict(set) # map { day: set of players who invested}
 
         multiplier_owners = set()
@@ -790,7 +808,7 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
             if split_scores:
                 date = e.datetime.date()
                 for (killer, victim) in e.kills:
-                    if killer not in day_investers[date] and victim not in previous_kills[killer]:
+                    if killer not in day_investers[date] and previous_kills[killer][victim] == 0:
                         to_invest = temp_scores[killer] * invest_prop
                         temp_scores[killer] -= to_invest
                         perm_scores[killer] += to_invest
@@ -800,10 +818,7 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
             point_deltas = {player: bs_allotment for (player, bs_allotment) in bs_points}
 
             for (killer, victim) in e.kills:
-                previous_kills[killer].add(victim)
-
                 is_wanted = int(wanted_manager.is_player_wanted(victim, e.datetime))
-
                 is_as_team = int(teams_enabled and (killer, victim) in kills_made_as_team)
                 is_with_multiplier = multipliers_enabled and killer in multiplier_owners
                 if team_multiplier_sharing_enabled and not is_with_multiplier:
@@ -818,16 +833,13 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
                     + is_wanted * (V * wb + Wb)
                     + is_as_team * (V * t + T)
                     + is_with_multiplier * (V * m + M)
-                )
+                ) * (pk ** previous_kills[killer][victim])
                 point_deltas[victim] = point_deltas.get(victim, 0) - (
                     V * d + D
                     + is_wanted * (V * wd + Wd)
-                )
-                # useful for debugging
-                """print(f"{killer} kills {victim}")
-                print(f"V = {V}")
-                print(f"killer gains {V} * {b} + {B} + {is_wanted} * ({V} * {wb} + {Wb}) + {is_as_team} * ({V} * {t} + {T}) + {is_with_multiplier} * ({V} * {m} + {M})")
-                print(f"victim loses {V} * {d} + {D} + {is_wanted} * ({V} * {wd} + {Wd})")"""
+                ) * (pv ** previous_kills[killer][victim])
+
+                previous_kills[killer][victim] += 1
 
             # resolve deltas once all worked out
             for player in point_deltas:

--- a/AU2/plugins/custom_plugins/MayWeekUtilitiesPlugin.py
+++ b/AU2/plugins/custom_plugins/MayWeekUtilitiesPlugin.py
@@ -29,6 +29,7 @@ from AU2.plugins.CorePlugin import registered_plugin
 from AU2.plugins.constants import WEBPAGE_WRITE_LOCATION
 from AU2.plugins.util.date_utils import get_now_dt
 from AU2.plugins.util.render_utils import Chapter, generate_news_pages, get_color, Manager
+from AU2.plugins.util.WantedManager import WantedManager
 
 
 HEX_COLS = [
@@ -177,8 +178,18 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
                 description="D = Fixed number of points lost by player when they die"
             ),
             ScoringParameter(
+                name="wanted_penalty_pct",
+                default_value=0,
+                description="wd = % of points additionally lost by a Wanted player when they die"
+            ),
+            ScoringParameter(
+                name="wanted_penalty_fixed",
+                default_value=0,
+                description="Wd = Fixed number of additional penalty points lost by a Wanted player when they die"
+            ),
+            ScoringParameter(
                 name="kill_bonus_pct",
-                default_value=135,
+                default_value=35,
                 description="b = % of victim's points gained by the killer"
             ),
             ScoringParameter(
@@ -187,24 +198,34 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
                 description="B = Fixed points awarded for each kill"
             ),
             ScoringParameter(
+                name="wanted_bonus_pct",
+                default_value=0,
+                description="wb = % of a Wanted victim's points additionally gained by the killer"
+            ),
+            ScoringParameter(
+                name="wanted_bonus_fixed",
+                default_value=0,
+                description="Wb = Fixed bonus points awarded for each kill of a Wanted player"
+            ),
+            ScoringParameter(
                 name="team_bonus_pct",
-                default_value=115,
-                description="t = % bonus points awarded overall when the kill is made with a team"
+                default_value=15,
+                description="t = % of victim's points additionally gained by the killer when the kill is made with a team"
             ),
             ScoringParameter(
                 name="team_bonus_fixed",
                 default_value=1,
-                description="T = Fixed points awarded when kills are made with a team"
+                description="T = Fixed bonus points awarded when kills are made with a team"
             ),
             ScoringParameter(
                 name="multiplier_bonus_pct",
-                default_value=125,
-                description="m = % bonus points obtained for a player when they kill with a multiplier"
+                default_value=25,
+                description="m = % of victim's points additionally gained by the killer when they kill with a multiplier"
             ),
             ScoringParameter(
                 name="multiplier_bonus_fixed",
                 default_value=1,
-                description="M = Fixed points awarded when kills are made with a multiplier"
+                description="M = Fixed bonus points awarded when kills are made with a multiplier"
             ),
         ]
         self.html_ids.update({param.name: self.identifier + "_" + param.name.lower() for param in self.scoring_parameters})
@@ -213,8 +234,15 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
         for p in self.scoring_parameters:
             self.ps_defaults[p.name] = p.default_value
 
-        self.printable_gain_formula = "(Temporary) Points gained from kills: ((V*b + B)*t + T)*m + M"
-        self.printable_loss_formula = "(Temporary) Points lost from death: -V*d - D"
+        self.formula_explanation = (
+            "The scoring formula for each kill is defined as follows:",
+            "Let V be the victim's (temporary) points prior to the kill."
+            "Let I_w = 1 if the victim is Wanted, 0 otherwise.",
+            "Let I_t = 1 if the kill was made as a team kill, 0 otherwise.",
+            "Let I_m = 1 if the killer was benefiting from a Multiplier, 0 otherwise.",
+            "Then (temporary) points GAINED by the killer = (b*V + B) + I_w * (wb*V + Wb) + I_t * (t*V + T) + I_m * (m*V + M)",
+            "And (temporary) points LOST by the victim = (d*V + D) + I_w * (wd * V + Wd)",
+        )
 
         self.exports = [
             Export(
@@ -427,9 +455,7 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
 
     def ask_set_scoring_params(self):
         return [
-            Label("Set scoring parameters for the following formulae:"),
-            Label(self.printable_gain_formula),
-            Label(self.printable_loss_formula),
+            *(Label(t) for t in self.formula_explanation),  # need separate label for each line
             *(IntegerEntry(
                 title=param.description,
                 default=self.gsdb_get(param.name, param.default_value),
@@ -710,8 +736,12 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
         """
         d = self.gsdb_get("death_penalty_pct", 0) / 100
         D = self.gsdb_get("death_penalty_fixed", 0)
+        wd = self.gsdb_get("wanted_penalty_pct", 0) / 100
+        Wd = self.gsdb_get("wanted_penalty_fixed", 0)
         b = self.gsdb_get("kill_bonus_pct", 0) / 100
         B = self.gsdb_get("kill_bonus_fixed", 0)
+        wb = self.gsdb_get("wanted_bonus_pct", 0) / 100
+        Wb = self.gsdb_get("wanted_bonus_fixed", 0)
         t = self.gsdb_get("team_bonus_pct", 0) / 100
         T = self.gsdb_get("team_bonus_fixed", 0)
         m = self.gsdb_get("multiplier_bonus_pct", 0) / 100
@@ -720,8 +750,11 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
         Sf = self.gsdb_get("starting_score_full", 0)
         invest_prop = self.gsdb_get("Investment %") / 100
 
+        wanted_manager = WantedManager()
+        wanted_manager.activated = True
         # passing a team manager allows us to extract team information after this function runs
         team_manager = team_manager or self.TeamManager()
+
 
         temp_scores: Dict[str, float] = {a.identifier: Sf if not a.is_city_watch else Sc for a in ASSASSINS_DATABASE.get_filtered(
             include_hidden = lambda _: True  # probably not necessary in May Week (since no resurrection as city watch),
@@ -741,8 +774,8 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
                 teams_enabled and multipliers_enabled
                 and self.gsdb_get("Share Multipliers?", self.ps_defaults["Share Multipliers?"])
         )
-        split_scores = gimmick_map.get("investment")
-        deplete_perm_pts = self.gsdb_get("Deplete Permanent Points?")
+        split_scores = gimmick_map.get("investment", False)
+        deplete_perm_pts = split_scores and self.gsdb_get("Deplete Permanent Points?")
         perm_pts_floor = self.gsdb_get("Perm Points Floor")
 
         for e in EVENTS_DATABASE.events_chronologically():
@@ -768,23 +801,33 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
 
             for (killer, victim) in e.kills:
                 previous_kills[killer].add(victim)
-                is_as_team = teams_enabled and (killer, victim) in kills_made_as_team
+
+                is_wanted = int(wanted_manager.is_player_wanted(victim, e.datetime))
+
+                is_as_team = int(teams_enabled and (killer, victim) in kills_made_as_team)
                 is_with_multiplier = multipliers_enabled and killer in multiplier_owners
                 if team_multiplier_sharing_enabled and not is_with_multiplier:
                     # check whether the killer is in the same team as someone with a multiplier
                     is_with_multiplier = any(memb in multiplier_owners for memb in team_to_members[member_to_team[killer]])
+                is_with_multiplier = int(is_with_multiplier)
 
-                # apply team and multiplier bonuses (% and fixed) iff they apply
-                # (side note: maybe calling the items that grant bonuses multipliers is a little confusing in this
-                #  context, since they are neither the only ways to get multiplicative bonuses (teams do that)
-                #  nor do they only grant multiplicative bonuses)
-                t_now = t if is_as_team else 1
-                T_now = T if is_as_team else 0
-                m_now = m if is_with_multiplier else 1
-                M_now = M if is_with_multiplier else 0
+                V = temp_scores[victim]
 
-                point_deltas[killer] = point_deltas.get(killer, 0) + ((temp_scores[victim]*b + B)*t_now + T_now)*m_now + M_now
-                point_deltas[victim] = point_deltas.get(victim, 0) - temp_scores[victim]*d - D
+                point_deltas[killer] = point_deltas.get(killer, 0) + (
+                    V * b + B
+                    + is_wanted * (V * wb + Wb)
+                    + is_as_team * (V * t + T)
+                    + is_with_multiplier * (V * m + M)
+                )
+                point_deltas[victim] = point_deltas.get(victim, 0) - (
+                    V * d + D
+                    + is_wanted * (V * wd + Wd)
+                )
+                # useful for debugging
+                """print(f"{killer} kills {victim}")
+                print(f"V = {V}")
+                print(f"killer gains {V} * {b} + {B} + {is_wanted} * ({V} * {wb} + {Wb}) + {is_as_team} * ({V} * {t} + {T}) + {is_with_multiplier} * ({V} * {m} + {M})")
+                print(f"victim loses {V} * {d} + {D} + {is_wanted} * ({V} * {wd} + {Wd})")"""
 
             # resolve deltas once all worked out
             for player in point_deltas:
@@ -805,6 +848,10 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
                     multiplier_owners.remove(loser)
                 if gainer is not None:
                     multiplier_owners.add(gainer)
+
+            # update wantedness; we do this *after* calculating scores so that if a victim somehow goes wanted in the
+            # same event they died, the killers don't get a bonus from that
+            wanted_manager.add_event(e)
 
         return temp_scores, perm_scores
 

--- a/AU2/plugins/custom_plugins/MayWeekUtilitiesPlugin.py
+++ b/AU2/plugins/custom_plugins/MayWeekUtilitiesPlugin.py
@@ -22,6 +22,7 @@ from AU2.html_components.SimpleComponents.IntegerEntry import IntegerEntry
 from AU2.html_components.SimpleComponents.Label import Label
 from AU2.html_components.SimpleComponents.LargeTextEntry import LargeTextEntry
 from AU2.html_components.SimpleComponents.InputWithDropDown import InputWithDropDown
+from AU2.html_components.SimpleComponents.SelectorList import SelectorList
 from AU2.html_components.SimpleComponents.Table import Table
 from AU2.plugins.AbstractPlugin import AbstractPlugin, AttributePairTableRow, ConfigExport, Export, NavbarEntry
 from AU2.plugins.CorePlugin import registered_plugin
@@ -39,16 +40,14 @@ HEX_COLS = [
 ]
 
 CREW_COLOR_TEMPLATE = 'style="background-color:{HEX}"'
-TEAM_ENTRY_TEMPLATE = "<td {CREW_COLOR}>{TEAM}</td>"
-TEAM_HDR_TEMPLATE = "<th>{TEAM_STR}</th>"
-SINGLE_SCORE_ENTRY_TEMPLATE = "<td {CREW_COLOR}>{POINTS}</td>"
-SPLIT_SCORE_ENTRY_TEMPLATE = "<td {CREW_COLOR}>{TEMP_POINTS}</td><td {CREW_COLOR}>{PERM_POINTS}</td>" + SINGLE_SCORE_ENTRY_TEMPLATE
-SINGLE_SCORE_HDR_TEMPLATE = "<th>{POINTS_STR}</th>"
-SPLIT_SCORE_HDR_TEMPLATE = "<th>{TEMP_PTS_STR}</th><th>{PERM_PTS_STR}</th>" + SINGLE_SCORE_HDR_TEMPLATE
+ENTRY_TEMPLATE = "<td {CREW_COLOR}>{VALUE}</td>"
+HDR_TEMPLATE = "<th>{HEADING}</th>"
+SPLIT_SCORE_ENTRY_TEMPLATE = "<td {CREW_COLOR}>{TEMP_POINTS}</td><td {CREW_COLOR}>{PERM_POINTS}</td><td {CREW_COLOR}>{POINTS}</td>"
+SPLIT_SCORE_HDR_TEMPLATE = "<th>{TEMP_PTS_STR}</th><th>{PERM_PTS_STR}</th><th>{POINTS_STR}</th>"
 PLAYER_ROW_TEMPLATE = "<tr><td>{REAL_NAME}</td><td>{PLAYER_TYPE}</td><td>{ADDRESS}</td><td>{COLLEGE}</td><td>{WATER_STATUS}</td><td>{NOTES}</td></tr>"
 PSEUDONYM_ROW_TEMPLATE = ("<tr><td {CREW_COLOR}>{PSEUDONYM}</td>"
                          "{POINTS_ENTRY}"
-                         "<td {CREW_COLOR}>{MULTIPLIER}</td>"
+                         "{MULTIPLIER_ENTRY}"
                          "{TEAM_ENTRY}</tr>")
 
 MAYWEEK_PLAYERS_NAVBAR_ENTRY = NavbarEntry("mw-players.html", "Players", -2)
@@ -92,7 +91,7 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
 
         self.html_ids = {
             "Team Names": self.identifier + "_team_names",
-            "Enable Teams?": self.identifier + "_enable_teams",
+            "Gimmicks": self.identifier + "_gimmicks",
             "Share Multipliers?": self.identifier + "_share_multipliers",
             "Investment %": self.identifier + "_investment_pct",
             "Invest first?": self.identifier + "_invest_first",
@@ -110,7 +109,7 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
 
         self.plugin_state = {
             "Team Names": "team_names",
-            "Enable Teams?": "enable_teams",
+            "Gimmick Map": "gimmick_map",
             "Share Multipliers?": "share_multipliers",
             "Investment %": "investment_pct",
             "Invest first?": "invest_first",
@@ -126,6 +125,7 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
 
         self.ps_defaults = {
             "Team Names": ["Team 1", "Team 2", "Team 3"],
+            "Gimmick Map": {},
             "Share Multipliers?": False,
             "Investment %": 0,
             "Invest first?": True,
@@ -143,6 +143,12 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
         ]
         self.html_ids.update({k: self.identifier + "_" + k.lower() for k in self.cosmetics})
         self.plugin_state.update({k: k.lower() for k in self.cosmetics})
+
+        self.gimmick_names = {
+            "teams": "Teams",
+            "multipliers": "Multipliers",
+            "investment": "Temporary/Permanent Points",
+        }
 
         self.scoring_parameters = [
             ScoringParameter(
@@ -216,10 +222,10 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
 
         self.config_exports = [
             ConfigExport(
-                identifier="may_week_enable_teams",
-                display_name="May Week -> Enable/disable Teams",
-                ask=self.ask_enable_teams,
-                answer=self.answer_enable_teams
+                identifier="may_week_set_gimmicks",
+                display_name="May Week -> Enable/disable Gimmicks",
+                ask=self.ask_set_gimmicks,
+                answer=self.answer_set_gimmicks
             ),
             ConfigExport(
                 identifier="may_week_set_team_names",
@@ -296,20 +302,23 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
     def eps_set(self, e: Event, plugin_state_id, data):
         e.pluginState.setdefault(self.identifier, {})[self.plugin_state[plugin_state_id]] = data
 
-
-    def ask_enable_teams(self):
-        return [Checkbox(
-            title="Enable teams?",
-            identifier=self.html_ids["Enable Teams?"],
-            checked=self.gsdb_get("Enable Teams?", False)
-        )]
-
-    def answer_enable_teams(self, html_response):
-        enabled = html_response[self.html_ids["Enable Teams?"]]
-        self.gsdb_set("Enable Teams?", enabled)
+    def ask_set_gimmicks(self) -> List[HTMLComponent]:
         return [
-            Label("Teams are now: " + "enabled" if enabled else "disabled")
+            SelectorList(
+                identifier=self.html_ids["Gimmicks"],
+                title="Which May Week features should be enabled?",
+                options=[(v, k) for k, v in self.gimmick_names.items()],
+                defaults=[k for k, v in self.gsdb_get("Gimmick Map", {}).items() if v]
+            )
         ]
+
+    def answer_set_gimmicks(self, html_response) -> List[HTMLComponent]:
+        gimmicks = html_response[self.html_ids["Gimmicks"]]
+        self.gsdb_set("Gimmick Map", {ident: True for ident in gimmicks})
+        return [
+            Label("[MAY WEEK] Enabled: " + ', '.join(self.gimmick_names[ident] for ident in gimmicks))
+        ]
+
 
     def ask_enable_multiplier_team_sharing(self):
         return [Checkbox(
@@ -326,13 +335,9 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
         ]
 
     def ask_config_perm_points(self):
-        # TODO: would like to have this in some kind of conditional metacomponent,
-        #       where enable/disable split asked first, and only if enable ask about other params!
-        #       would be trivial with the refactoring in #164. Maybe do anyway?
         return [
             FloatEntry(
-                title="% of Temporary Points to convert into Permanent Points when investing. "
-                      "(Set to 0 to disable the split into temporary/permanent points)",
+                title="% of Temporary Points to convert into Permanent Points when investing",
                 identifier=self.html_ids["Investment %"],
                 default=self.gsdb_get("Investment %"),
             ),
@@ -481,47 +486,57 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
         ]
 
     def render_assassin_summary(self, assassin: Assassin) -> List[AttributePairTableRow]:
-        team_str = self.get_cosmetic_name("Teams").capitalize()
-        multiplier_str = self.get_cosmetic_name("Multiplier").lower()
-        temp_score_str = self.get_cosmetic_name("Temporary Points")
-        perm_score_str = self.get_cosmetic_name("Permanent Points")
-        split_scores = bool(self.gsdb_get("Investment %"))
-        teams_enabled = self.gsdb_get("Enable Teams?", False)
-        team_names = self.gsdb_get("Team Names", self.ps_defaults["Team Names"])
+        gimmick_map = self.gsdb_get("Gimmick Map")
+        teams_enabled = gimmick_map.get("teams", False)
+        split_scores = gimmick_map.get("investment", False)
+        multipliers_enabled = gimmick_map.get("multipliers", False)
         team_manager = self.TeamManager()
-        scores, perm_scores = self.calculate_scores(team_manager=team_manager)
-        multiplier_owners = self.get_multiplier_owners()
-        multiplier_beneficiaries = self.get_multiplier_beneficiaries(multiplier_owners, team_manager)
+        temp_scores, perm_scores = self.calculate_scores(team_manager=team_manager)
 
-        team = team_manager.member_to_team[assassin.identifier]
-        team_name = team_names[team] if team is not None else "(Individual)"
+        score_str = self.get_cosmetic_name("Points")
+        score = temp_scores[assassin.identifier] + perm_scores[assassin.identifier]
+        response = [(score_str, score)]
+        if split_scores:
+            temp_score_str = self.get_cosmetic_name("Temporary Points")
+            perm_score_str = self.get_cosmetic_name("Permanent Points")
+            response.extend((
+                (temp_score_str, temp_scores[assassin.identifier]),
+                (perm_score_str, perm_scores[assassin.identifier]),
+            ))
 
-        return [
-            (temp_score_str, scores[assassin.identifier]),
-            *((perm_score_str, perm_scores[assassin.identifier]) for _ in range(split_scores)),
-            # will render as plural, but eh
-            *((team_str, team_name) for _ in range(teams_enabled)),
-            (f"Has {multiplier_str}", "Y" if assassin.identifier in multiplier_owners else "N"),
-            (f"Benefits from {multiplier_str}", "Y" if assassin.identifier in multiplier_beneficiaries else "N")
-        ]
+        if teams_enabled:
+            team_str = self.get_cosmetic_name("Teams").capitalize()
+            team_names = self.gsdb_get("Team Names", self.ps_defaults["Team Names"])
+            team = team_manager.member_to_team[assassin.identifier]
+            team_name = team_names[team] if team is not None else "(Individual)"
+            response.extend(((team_str, team_name),))
+
+        if multipliers_enabled:
+            multiplier_str = self.get_cosmetic_name("Multiplier").lower()
+            multiplier_owners = self.get_multiplier_owners()
+            multiplier_beneficiaries = self.get_multiplier_beneficiaries(multiplier_owners, team_manager)
+            response.extend((
+                (f"Has {multiplier_str}", "Y" if assassin.identifier in multiplier_owners else "N"),
+                (f"Benefits from {multiplier_str}", "Y" if assassin.identifier in multiplier_beneficiaries else "N"),
+            ))
+        return response
 
     def render_event_summary(self, event: Event) -> List[AttributePairTableRow]:
         response = []
-
-        if self.gsdb_get("Enable Teams?", False):
-            team_names = self.gsdb_get("Team Names", self.ps_defaults["Team Names"])
-            team_str = self.get_cosmetic_name("Teams").capitalize()
-            for i, (a_id, t_id) in enumerate(self.eps_get(event, "Team Changes", {}).items()):
-                a = ASSASSINS_DATABASE.get(a_id)
-                change_str = f"{a.snapshot()} " + (
-                    f"joins {team_names[t_id]}" if t_id is not None
-                    else "goes it alone"
-                )
-                response.append((f"{team_str} Change {i+1}", change_str))
-            for i, (killer_id, victim_id) in enumerate(self.eps_get(event, "Kills as Team", [])):
-                killer = ASSASSINS_DATABASE.get(killer_id)
-                victim = ASSASSINS_DATABASE.get(victim_id)
-                response.append((f"{team_str} Kill {i+1} ", f"{killer.snapshot()} kills {victim.snapshot()}"))
+        
+        team_names = self.gsdb_get("Team Names", self.ps_defaults["Team Names"])
+        team_str = self.get_cosmetic_name("Teams").capitalize()
+        for i, (a_id, t_id) in enumerate(self.eps_get(event, "Team Changes", {}).items()):
+            a = ASSASSINS_DATABASE.get(a_id)
+            change_str = f"{a.snapshot()} " + (
+                f"joins {team_names[t_id]}" if t_id is not None
+                else "goes it alone"
+            )
+            response.append((f"{team_str} Change {i+1}", change_str))
+        for i, (killer_id, victim_id) in enumerate(self.eps_get(event, "Kills as Team", [])):
+            killer = ASSASSINS_DATABASE.get(killer_id)
+            victim = ASSASSINS_DATABASE.get(victim_id)
+            response.append((f"{team_str} Kill {i+1} ", f"{killer.snapshot()} kills {victim.snapshot()}"))
 
         multiplier_str = self.get_cosmetic_name("Multiplier").capitalize()
         for i, (old_owner, receiver) in enumerate(self.eps_get(event, "Multiplier Transfers", [])):
@@ -552,7 +567,10 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
         return list(owners)
 
     def get_multiplier_beneficiaries(self, multiplier_owners: List[str], team_manager) -> List[str]:
-        teams_enabled = self.gsdb_get("Enable Teams?", False)
+        gimmick_map = self.gsdb_get("Gimmick Map")
+        if not gimmick_map.get("multipliers", False):
+            return []
+        teams_enabled = gimmick_map.get("teams", False)
         if teams_enabled:
             member_to_team = team_manager.member_to_team
             team_to_members = team_manager.team_to_member_map()
@@ -568,9 +586,11 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
         return multiplier_beneficiaries
 
     def on_event_request_create(self) -> List[HTMLComponent]:
+        gimmick_map = self.gsdb_get("Gimmick Map")
         multiplier_str = self.get_cosmetic_name("Multiplier").lower()
+        multipliers_enabled = gimmick_map.get("multipliers", False)
         teams_str = self.get_cosmetic_name("Teams").lower()
-        teams_enabled = self.gsdb_get("Enable Teams?", False)
+        teams_enabled = gimmick_map.get("teams", False)
         team_names = self.gsdb_get("Team Names", self.ps_defaults["Team Names"])
         return [
             Dependency(
@@ -583,12 +603,12 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
                     ),
                     Label(f"[MAY WEEK] WARNING! Changing this will not play nicely if the {multiplier_str} has already "
                           "transferred again after this!"),
-                    AssassinDependentTransferEntry(
+                    *(AssassinDependentTransferEntry(
                         assassins_list_identifier="CorePlugin_assassin_pseudonym",
                         identifier=self.html_ids["Multiplier Transfer"],
                         owners=self.get_multiplier_owners(),
                         title=f"[MAY WEEK] Any {multiplier_str} transfers? (None -> A adds a new {multiplier_str}, A -> None deletes it)"
-                    ),
+                    ) for _ in range(multipliers_enabled)),
 
                     *(AssassinDependentInputWithDropDown(
                         pseudonym_list_identifier="CorePlugin_assassin_pseudonym",
@@ -612,7 +632,8 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
         ]
 
     def on_event_create(self, e: Event, html_response) -> List[HTMLComponent]:
-        self.eps_set(e, "Multiplier Transfers", html_response[self.html_ids["Multiplier Transfer"]])
+        if self.html_ids["Multiplier Transfers"] in html_response:
+            self.eps_set(e, "Multiplier Transfers", html_response[self.html_ids["Multiplier Transfer"]])
         self.eps_set(e, "BS Points",  html_response[self.html_ids["BS Points"]])
         if self.html_ids["Kills as Team"] in html_response:
             self.eps_set(e, "Kills as Team", html_response[self.html_ids["Kills as Team"]])
@@ -621,9 +642,11 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
         return [Label("[MAY WEEK] Success!")]
 
     def on_event_request_update(self, e: Event) -> List[HTMLComponent]:
+        gimmick_map = self.gsdb_get("Gimmick Map")
         multiplier_str = self.get_cosmetic_name("Multiplier").lower()
+        multipliers_enabled = gimmick_map.get("multipliers", False)
         teams_str = self.get_cosmetic_name("Teams").lower()
-        teams_enabled = self.gsdb_get("Enable Teams?", False)
+        teams_enabled = gimmick_map.get("teams", False)
         team_names = self.gsdb_get("Team Names", self.ps_defaults["Team Names"])
         return [
             Dependency(
@@ -637,13 +660,13 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
                     ),
                     Label(f"[MAY WEEK] WARNING! Changing this will not play nicely if the {multiplier_str} has already "
                           "transferred again after this!"),
-                    AssassinDependentTransferEntry(
+                    *(AssassinDependentTransferEntry(
                         assassins_list_identifier="CorePlugin_assassin_pseudonym",
                         identifier=self.html_ids["Multiplier Transfer"],
                         owners=self.get_multiplier_owners(before_event=int(e._Event__secret_id)),
                         title=f"[MAY WEEK] Any {multiplier_str} transfers?",
                         default=self.eps_get(e, "Multiplier Transfers", [])
-                    ),
+                    ) for _ in range(multipliers_enabled)),
                     *(AssassinDependentInputWithDropDown(
                         pseudonym_list_identifier="CorePlugin_assassin_pseudonym",
                         identifier=self.html_ids["Team Changes"],
@@ -667,7 +690,8 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
         ]
 
     def on_event_update(self, e: Event, html_response) -> List[HTMLComponent]:
-        self.eps_set(e, "Multiplier Transfers", html_response[self.html_ids["Multiplier Transfer"]])
+        if self.html_ids["Multiplier Transfers"] in html_response:
+            self.eps_set(e, "Multiplier Transfers", html_response[self.html_ids["Multiplier Transfer"]])
         self.eps_set(e, "BS Points",  html_response[self.html_ids["BS Points"]])
         if self.html_ids["Kills as Team"] in html_response:
             self.eps_set(e, "Kills as Team", html_response[self.html_ids["Kills as Team"]])
@@ -676,6 +700,10 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
         return [Label("[MAY WEEK] Success!")]
 
     def calculate_scores(self, before_event: int = float("inf"), team_manager = None) -> (Dict[str, float], Dict[str, float]):
+        """
+        Returns:
+            (temporary points, permanent points)
+        """
         d = self.gsdb_get("death_penalty_pct", 0) / 100
         D = self.gsdb_get("death_penalty_fixed", 0)
         b = self.gsdb_get("kill_bonus_pct", 0) / 100
@@ -691,7 +719,7 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
         # passing a team manager allows us to extract team information after this function runs
         team_manager = team_manager or self.TeamManager()
 
-        scores: Dict[str, float] = {a.identifier: Sf if not a.is_city_watch else Sc for a in ASSASSINS_DATABASE.get_filtered(
+        temp_scores: Dict[str, float] = {a.identifier: Sf if not a.is_city_watch else Sc for a in ASSASSINS_DATABASE.get_filtered(
             include_hidden = lambda _: True  # probably not necessary in May Week (since no resurrection as city watch),
                                              # but just in case...
         )}
@@ -702,17 +730,23 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
         day_investers: Dict[datetime.date, Set[str]] = defaultdict(set) # map { day: set of players who invested}
 
         multiplier_owners = set()
-        teams_enabled = self.gsdb_get("Enable Teams?", False)
-        team_multiplier_sharing_enabled = teams_enabled and self.gsdb_get("Share Multipliers?", self.ps_defaults["Share Multipliers?"])
+        gimmick_map = self.gsdb_get("Gimmick Map")
+        teams_enabled = gimmick_map.get("teams", False)
+        multipliers_enabled = gimmick_map.get("multipliers", False)
+        team_multiplier_sharing_enabled = (
+                teams_enabled and multipliers_enabled
+                and self.gsdb_get("Share Multipliers?", self.ps_defaults["Share Multipliers?"])
+        )
+        split_scores = gimmick_map.get("investment")
         invest_first = self.gsdb_get("Invest first?")
 
-        if invest_prop:
+        if split_scores:
             def do_investments(e: Event):
                 for (killer, victim) in e.kills:
                     date = e.datetime.date()
                     if killer not in day_investers[date] and victim not in previous_kills[killer]:
-                        to_invest = scores[killer] * invest_prop
-                        scores[killer] -= to_invest
+                        to_invest = temp_scores[killer] * invest_prop
+                        temp_scores[killer] -= to_invest
                         perm_scores[killer] += to_invest
                         day_investers[date].add(killer)
         else:
@@ -741,7 +775,7 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
             for (killer, victim) in e.kills:
                 previous_kills[killer].add(victim)
                 is_as_team = teams_enabled and (killer, victim) in kills_made_as_team
-                is_with_multiplier = killer in multiplier_owners
+                is_with_multiplier = multipliers_enabled and killer in multiplier_owners
                 if team_multiplier_sharing_enabled and not is_with_multiplier:
                     # check whether the killer is in the same team as someone with a multiplier
                     is_with_multiplier = any(memb in multiplier_owners for memb in team_to_members[member_to_team[killer]])
@@ -755,14 +789,14 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
                 m_now = m if is_with_multiplier else 1
                 M_now = M if is_with_multiplier else 0
 
-                point_deltas[killer] = point_deltas.get(killer, 0) + ((scores[victim]*b + B)*t_now + T_now)*m_now + M_now
-                point_deltas[victim] = point_deltas.get(victim, 0) - scores[victim]*d - D
+                point_deltas[killer] = point_deltas.get(killer, 0) + ((temp_scores[victim]*b + B)*t_now + T_now)*m_now + M_now
+                point_deltas[victim] = point_deltas.get(victim, 0) - temp_scores[victim]*d - D
 
             # resolve deltas once all worked out
             for player in point_deltas:
                 # use max or else you can LOSE points by killing someone!
                 # (specifically, if killing a player with negative points would lose you points)
-                scores[player] = max(0, scores[player] + point_deltas[player])
+                temp_scores[player] = max(0, temp_scores[player] + point_deltas[player])
 
             if not invest_first:
                 do_investments(e)
@@ -774,7 +808,7 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
                 if gainer is not None:
                     multiplier_owners.add(gainer)
 
-        return scores, perm_scores
+        return temp_scores, perm_scores
 
     def on_page_generate(self, htmlResponse, navbar_entries) -> List[HTMLComponent]:
         """
@@ -790,11 +824,15 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
         """
 
         # player info page
+
+        gimmick_map = self.gsdb_get("Gimmick Map")
+        teams_enabled = gimmick_map.get("teams", False)
+        multipliers_enabled = gimmick_map.get("multipliers", False)
+        split_scores = gimmick_map.get("investment", False)
+
         team_manager = self.TeamManager()
         temp_scores, perm_scores = self.calculate_scores(team_manager=team_manager)
         multiplier_owners = set(self.get_multiplier_owners())
-        teams_enabled = self.gsdb_get("Enable Teams?", False)
-        split_scores = bool(self.gsdb_get("Investment %"))
         member_to_team = team_manager.member_to_team
         team_to_members = team_manager.team_to_member_map()
         team_names = self.gsdb_get("Team Names", self.ps_defaults["Team Names"])
@@ -814,24 +852,28 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
         for (score, a_id) in sorted(((v, k) for (k, v) in scores.items()), reverse=True):
             team_id = member_to_team[a_id]
             crew_color = (CREW_COLOR_TEMPLATE.format(HEX=team_to_hex_col[team_id]) if team_id is not None else "")
-            team_entry = (TEAM_ENTRY_TEMPLATE.format(TEAM=team_names[team_id], CREW_COLOR=crew_color) if team_id is not None else "")
+            team_entry = ENTRY_TEMPLATE.format(
+                VALUE=team_names[team_id] if team_id is not None else "",
+                CREW_COLOR=crew_color
+            ) if teams_enabled else ""
+            multiplier_entry = ENTRY_TEMPLATE.format(
+                VALUE="Y" if a_id in multiplier_beneficiaries else "",
+                CREW_COLOR=crew_color
+            ) if multipliers_enabled else ""
             points_entry = SPLIT_SCORE_ENTRY_TEMPLATE.format(
                 CREW_COLOR=crew_color,
                 TEMP_POINTS=temp_scores[a_id],
                 PERM_POINTS=perm_scores[a_id],
                 POINTS=score
-            ) if split_scores else SINGLE_SCORE_ENTRY_TEMPLATE.format(
-                CREW_COLOR=crew_color,
-                POINTS=score
-            )
+            ) if split_scores else ENTRY_TEMPLATE.format(CREW_COLOR=crew_color, VALUE=score)
 
             assassin = ASSASSINS_DATABASE.get(a_id)
             pseudonym_rows.append(
                 PSEUDONYM_ROW_TEMPLATE.format(
                     CREW_COLOR=crew_color,
                     PSEUDONYM=assassin.all_pseudonyms(),
-                    POINTS_ENTRY = points_entry,
-                    MULTIPLIER="Y" if a_id in multiplier_beneficiaries else "",
+                    POINTS_ENTRY=points_entry,
+                    MULTIPLIER_ENTRY=multiplier_entry,
                     TEAM_ENTRY=team_entry,
                 )
             )
@@ -857,15 +899,17 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
                 PSEUDONYM_ROWS = "\n".join(pseudonym_rows),
                 PLAYER_ROWS = "\n".join(player_rows),
                 YEAR = get_now_dt().year,
-                MULTIPLIER_STR = self.gsdb_get("Multiplier", "Multiplier"),
-                TEAM_COLUMN_HDR = TEAM_HDR_TEMPLATE.format(
-                    TEAM_STR = self.get_cosmetic_name("Teams")
+                MULTIPLIER_COLUMN_HDR = HDR_TEMPLATE.format(
+                    HEADING = self.get_cosmetic_name("Multiplier"),
+                ) if multipliers_enabled else "",
+                TEAM_COLUMN_HDR = HDR_TEMPLATE.format(
+                    HEADING = self.get_cosmetic_name("Teams")
                 ) if teams_enabled else "",
                 POINTS_HDR = SPLIT_SCORE_HDR_TEMPLATE.format(
                     TEMP_PTS_STR = self.get_cosmetic_name("Temporary Points"),
                     PERM_PTS_STR = self.get_cosmetic_name("Permanent Points"),
                     POINTS_STR = self.get_cosmetic_name("Points"),
-                ) if split_scores else SINGLE_SCORE_HDR_TEMPLATE.format(POINTS_STR = self.get_cosmetic_name("Points"))
+                ) if split_scores else HDR_TEMPLATE.format(HEADING = self.get_cosmetic_name("Points"))
             ))
 
         # may week news page

--- a/AU2/plugins/custom_plugins/MayWeekUtilitiesPlugin.py
+++ b/AU2/plugins/custom_plugins/MayWeekUtilitiesPlugin.py
@@ -326,11 +326,13 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
 
 
     def ask_enable_multiplier_team_sharing(self):
-        return [Checkbox(
-            title="Should multipliers be shared within teams?",
-            identifier=self.html_ids["Share Multipliers?"],
-            checked=self.gsdb_get("Share Multipliers?", self.ps_defaults["Share Multipliers?"])
-        )]
+        return [
+            Checkbox(
+                title="Should multipliers be shared within teams?",
+                identifier=self.html_ids["Share Multipliers?"],
+                checked=self.gsdb_get("Share Multipliers?", self.ps_defaults["Share Multipliers?"])
+            )
+        ]
 
     def answer_enable_multiplier_team_sharing(self, html_response):
         enabled = html_response[self.html_ids["Share Multipliers?"]]
@@ -395,7 +397,10 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
 
     def ask_name_teams(self):
         existing_ranks: List[str] = self.gsdb_get("Team Names", self.ps_defaults["Team Names"])
-        default_text = "# Enter team names each on a new line.\n# Lines starting with hashtags will be ignored.\n"
+        default_text = ("# Enter team names each on a new line.\n"
+                        "# Lines starting with hashtags will be ignored.\n"
+                        "# Note that each team is identified by its position in this list, so if editing team names "
+                        "during a game, only add new teams to the *end* of this list.\n")
         return [
             LargeTextEntry(
                 title="Rename teams",
@@ -447,13 +452,10 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
         for param in self.scoring_parameters:
             self.gsdb_set(param.name, html_response[self.html_ids[param.name]])
 
-        points_floor = html_response[self.html_ids["Points Floor"]]
-        self.gsdb_set("Points Floor", points_floor)
-
         return [
             Label(title=f"Parameter {param.name} set to {html_response[self.html_ids[param.name]]}")
             for param in self.scoring_parameters
-        ] + [Label(f"Points floor set to {points_floor}")]
+        ]
 
     def ask_teams_summary(self) -> List[HTMLComponent]:
         return [
@@ -967,3 +969,28 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
         )
 
         return [Label("[MAY WEEK] Success!")]
+
+    def on_request_setup_game(self, _) -> List[HTMLComponent]:
+        return [
+            *self.ask_set_gimmicks(),
+            Label("[IMPORTANT] Below you will be asked to set various parameters for May Week features. "
+                  "Due to technical limitations this may include parameters for some of the features that you did not "
+                  "enable above. Such parameters may be safely ignored."),
+            *self.ask_set_scoring_params(),
+            Label("[MAY WEEK] Below you can set team names. Players are assigned to teams in Events, as teams may "
+                  "change over the course of the game."),
+            *self.ask_name_teams(),
+            *self.ask_enable_multiplier_team_sharing(),
+            *self.ask_config_perm_points(),
+            *self.ask_tweak_cosmetics(),
+        ]
+
+    def on_setup_game(self, html_response) -> List[HTMLComponent]:
+        return [
+            *self.answer_set_gimmicks(html_response),
+            *self.answer_set_scoring_params(html_response),
+            *self.answer_name_teams(html_response),
+            *self.answer_enable_multiplier_team_sharing(html_response),
+            *self.answer_config_perm_points(html_response),
+            *self.answer_tweak_cosmetics(html_response),
+        ]

--- a/AU2/plugins/custom_plugins/MayWeekUtilitiesPlugin.py
+++ b/AU2/plugins/custom_plugins/MayWeekUtilitiesPlugin.py
@@ -16,6 +16,7 @@ from AU2.html_components.DependentComponents.AssassinDependentInputWithDropdown 
 from AU2.html_components.MetaComponents.Dependency import Dependency
 from AU2.html_components.SimpleComponents.Checkbox import Checkbox
 from AU2.html_components.SimpleComponents.DefaultNamedSmallTextbox import DefaultNamedSmallTextbox
+from AU2.html_components.SimpleComponents.FloatEntry import FloatEntry
 from AU2.html_components.SimpleComponents.IntegerEntry import IntegerEntry
 from AU2.html_components.SimpleComponents.Label import Label
 from AU2.html_components.SimpleComponents.LargeTextEntry import LargeTextEntry
@@ -88,6 +89,11 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
             "Team Names": self.identifier + "_team_names",
             "Enable Teams?": self.identifier + "_enable_teams",
             "Share Multipliers?": self.identifier + "_share_multipliers",
+            "Investment %": self.identifier + "_investment_pct",
+            "Invest first?": self.identifier + "_invest_first",
+            "Temp Points Floor": self.identifier + "_temp_pts_floor",
+            "Deplete Permanent Points?": self.identifier + "_deplete_perm_pts",
+            "Perm Points Floor": self.identifier + "_perm_pts_floor",
             "Assassins": self.identifier + "_assassins",
             "Team ID": self.identifier + "_team_id",
             "Team Changes": self.identifier + "_team_changes",
@@ -101,6 +107,11 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
             "Team Names": "team_names",
             "Enable Teams?": "enable_teams",
             "Share Multipliers?": "share_multipliers",
+            "Investment %": "investment_pct",
+            "Invest first?": "invest_first",
+            "Temp Points Floor": "temp_pts_floor",
+            "Deplete Permanent Points?": "deplete_perm_pts",
+            "Perm Points Floor": "perm_pts_floor",
             "Team Members": "team_members",
             "Team Changes": "team_changes",
             "Multiplier Transfers": "multiplier_transfers",
@@ -110,12 +121,19 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
 
         self.ps_defaults = {
             "Team Names": ["Team 1", "Team 2", "Team 3"],
-            "Share Multipliers?": False
+            "Share Multipliers?": False,
+            "Investment %": 0,
+            "Invest first?": True,
+            "Temp Points Floor": 0,
+            "Deplete Permanent Points?": True,
+            "Perm Points Floor": None,
         }
 
         self.cosmetics = [
             "Multiplier",
             "Teams",
+            "Temporary Points",
+            "Permanent Points",
         ]
         self.html_ids.update({k: self.identifier + "_" + k.lower() for k in self.cosmetics})
         self.plugin_state.update({k: k.lower() for k in self.cosmetics})
@@ -170,13 +188,13 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
                 name="multiplier_bonus_fixed",
                 default_value=1,
                 description="M = Fixed points awarded when kills are made with a multiplier"
-            )
+            ),
         ]
         self.html_ids.update({param.name: self.identifier + "_" + param.name.lower() for param in self.scoring_parameters})
         self.plugin_state.update({param.name: param.identifier() for param in self.scoring_parameters})
 
         for p in self.scoring_parameters:
-            self.gsdb_set(p.name, p.default_value)
+            self.ps_defaults[p.name] = p.default_value
 
         self.printable_gain_formula = "Points gained from kills: ((V*b + B)*t + T)*m + M"
         self.printable_loss_formula = "Points lost from death: -V*d - D"
@@ -208,6 +226,12 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
                 display_name="May Week -> Enable/disable multiplier team sharing",
                 ask=self.ask_enable_multiplier_team_sharing,
                 answer=self.answer_enable_multiplier_team_sharing
+            ),
+            ConfigExport(
+                identifier="may_week_config_temp_points",
+                display_name="May Week -> Configure Temporary Points",
+                ask=self.ask_config_temp_points,
+                answer=self.answer_config_temp_points,
             ),
             ConfigExport(
                 identifier="may_week_cosmetics",
@@ -251,8 +275,11 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
                 return memb_map
         self.TeamManager = TeamManager
 
-    def gsdb_get(self, plugin_state_id, default):
-        return GENERIC_STATE_DATABASE.arb_state.get(self.identifier, {}).get(self.plugin_state[plugin_state_id], default)
+    def gsdb_get(self, plugin_state_id, default = None):
+        return GENERIC_STATE_DATABASE.arb_state.get(self.identifier, {}).get(
+            self.plugin_state[plugin_state_id],
+            self.ps_defaults.get(plugin_state_id, default)
+        )
 
     def gsdb_set(self, plugin_state_id, data):
         GENERIC_STATE_DATABASE.arb_state.setdefault(self.identifier, {})[self.plugin_state[plugin_state_id]] = data
@@ -291,6 +318,64 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
         return [
             Label("Team multiplier sharing is now: " + "enabled" if enabled else "disabled")
         ]
+
+    def ask_config_temp_points(self):
+        # TODO: would like to have this in some kind of conditional metacomponent,
+        #       where enable/disable split asked first, and only if enable ask about other params!
+        #       would be trivial with the refactoring in #164. Maybe do anyway?
+        return [
+            FloatEntry(
+                title="% of Temporary Points to convert into Permanent Points when investing. "
+                      "(Set to 0 to disable the split into temporary/permanent points)",
+                identifier=self.html_ids["Investment %"],
+                default=self.gsdb_get("Investment %"),
+            ),
+            # TODO: consider whether InputWithDropdown better?
+            Checkbox(
+                title="Invest Temporary Points BEFORE profiting from kills (and BS points)?",
+                identifier=self.html_ids["Invest first?"],
+                checked=self.gsdb_get("Invest first?"),
+            ),
+            FloatEntry(
+                title="Floor for Temporary Points (Temporary Points will not be allowed to decrease below this value; "
+                      "leave blank for no floor)",
+                identifier=self.html_ids["Temp Points Floor"],
+                default=self.gsdb_get("Temp Points Floor"),
+                optional=True,
+            ),
+            Checkbox(
+                title="Transfer Permanent Points back to Temporary Points to keep the latter above the floor?",
+                identifier=self.html_ids["Deplete Permanent Points?"],
+                checked=self.gsdb_get("Deplete Permanent Points?"),
+            ),
+            FloatEntry(
+                title="Floor for Permanent Points (Permanent Points will not be allowed to decrease below this value; "
+                      "leave blank for no floor)",
+                identifier=self.html_ids["Perm Points Floor"],
+                default=self.gsdb_get("Perm Points Floor"),
+                optional=True,
+            ),
+        ]
+
+    def answer_config_temp_points(self, html_response):
+        investment_pct = html_response[self.html_ids["Investment %"]]
+
+        if investment_pct < 0 or investment_pct > 100:
+            return [Label(f"[ERROR] Cannot invest {investment_pct}% of temporary points!")]
+
+        invest_first = html_response[self.html_ids["Invest first?"]]
+        temp_pts_floor = html_response[self.html_ids["Temp Points Floor"]]
+        deplete_perm_pts = html_response[self.html_ids["Deplete Permanent Points?"]]
+        perm_pts_floor = html_response[self.html_ids["Perm Points Floor"]]
+
+        self.gsdb_set("Investment %", investment_pct)
+        self.gsdb_set("Invest first?", invest_first)
+        self.gsdb_set("Temp Points Floor", temp_pts_floor)
+        self.gsdb_set("Deplete Permanent Points?", deplete_perm_pts)
+        self.gsdb_set("Perm Points Floor", perm_pts_floor)
+
+        # TODO: more informative message
+        return [Label("[MAY WEEK] Configured temporary points.")]
 
     def ask_name_teams(self):
         existing_ranks: List[str] = self.gsdb_get("Team Names", self.ps_defaults["Team Names"])

--- a/AU2/plugins/custom_plugins/MayWeekUtilitiesPlugin.py
+++ b/AU2/plugins/custom_plugins/MayWeekUtilitiesPlugin.py
@@ -10,7 +10,7 @@ from AU2.database.EventsDatabase import EVENTS_DATABASE
 from AU2.database.GenericStateDatabase import GENERIC_STATE_DATABASE
 from AU2.database.model import Event, Assassin
 from AU2.html_components import HTMLComponent
-from AU2.html_components.DependentComponents.AssassinDependentIntegerEntry import AssassinDependentIntegerEntry
+from AU2.html_components.DependentComponents.AssassinDependentFloatEntry import AssassinDependentFloatEntry
 from AU2.html_components.DependentComponents.AssassinDependentTransferEntry import AssassinDependentTransferEntry
 from AU2.html_components.DependentComponents.KillDependentSelector import KillDependentSelector
 from AU2.html_components.DependentComponents.AssassinDependentInputWithDropdown import AssassinDependentInputWithDropDown
@@ -630,7 +630,7 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
             Dependency(
                 dependentOn="CorePlugin_assassin_pseudonym",
                 htmlComponents=[
-                    AssassinDependentIntegerEntry(
+                    AssassinDependentFloatEntry(
                         pseudonym_list_identifier="CorePlugin_assassin_pseudonym",
                         identifier=self.html_ids["BS Points"],
                         title="[MAY WEEK] Want to award any BS points?",
@@ -691,7 +691,7 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
             Dependency(
                 dependentOn="CorePlugin_assassin_pseudonym",
                 htmlComponents=[
-                    AssassinDependentIntegerEntry(
+                    AssassinDependentFloatEntry(
                         pseudonym_list_identifier="CorePlugin_assassin_pseudonym",
                         identifier=self.html_ids["BS Points"],
                         title="Want to award any BS points?",

--- a/AU2/plugins/custom_plugins/MayWeekUtilitiesPlugin.py
+++ b/AU2/plugins/custom_plugins/MayWeekUtilitiesPlugin.py
@@ -813,7 +813,8 @@ class MayWeekUtilitiesPlugin(AbstractPlugin):
                     if deplete_perm_pts:
                         new_perm_score = perm_scores[player] + new_score
                         if perm_pts_floor is not None:
-                            perm_scores[player] = max(new_perm_score, perm_pts_floor)
+                            new_perm_score = max(new_perm_score, perm_pts_floor)
+                        perm_scores[player] = new_perm_score
                     new_score = 0
                 temp_scores[player] = new_score
 

--- a/AU2/plugins/custom_plugins/ScoringPlugin.py
+++ b/AU2/plugins/custom_plugins/ScoringPlugin.py
@@ -309,7 +309,7 @@ class ScoringPlugin(AbstractPlugin):
                                                        include_hidden=lambda a: not a.is_city_watch)
         formula = self.gsdb_get("Formula")
         score_manager = ScoreManager({a.identifier for a in full_players}, formula=formula, game_end=openseason_end)
-        events = sorted(EVENTS_DATABASE.events.values(), key=lambda e: e.datetime)
+        events = EVENTS_DATABASE.events_chronologically()
         for e in events:
             score_manager.add_event(e)
         rows = []
@@ -471,10 +471,8 @@ Syntax:
                                          ident: self.aps_get(ident, "Bonus")
                                          for ident in ASSASSINS_DATABASE.get_identifiers(include_hidden=True)
                                      })
-        events = sorted(EVENTS_DATABASE.events.values(),
-                        key=lambda e: e.datetime)
         openseason_end = get_game_end() or get_now_dt()
-        for e in events:
+        for e in EVENTS_DATABASE.events_chronologically():
             # stops the duel changing the openseason page
             if e.datetime > openseason_end:
                 break

--- a/AU2/plugins/custom_plugins/WantedPlugin.py
+++ b/AU2/plugins/custom_plugins/WantedPlugin.py
@@ -159,7 +159,7 @@ class WantedPlugin(AbstractPlugin):
         messages = []
         # sort by datetime to ensure we read events in chronological order
         # (umpires messing with event timings could affect the canon timeline!)
-        events = sorted(list(EVENTS_DATABASE.events.values()), key=lambda event: event.datetime)
+        events = EVENTS_DATABASE.events_chronologically()
 
         city_watch_ranks_enabled = GENERIC_STATE_DATABASE.plugin_map.get("CityWatchPlugin", False)
 

--- a/AU2/plugins/custom_plugins/html_templates/may_week_utils_players.html
+++ b/AU2/plugins/custom_plugins/html_templates/may_week_utils_players.html
@@ -22,7 +22,7 @@
 	<h3>Pseudonyms</h3> 
 	<table xmlns="" class="playerlist">
 		<!-- TODO: We should just have used jinja2 -->
-		<tr><th>Pseudonyms</th><th>Points</th><th>{MULTIPLIER_STR}</th>{TEAM_COLUMN_HDR}</tr>
+		<tr><th>Pseudonyms</th>{POINTS_HDR}<th>{MULTIPLIER_STR}</th>{TEAM_COLUMN_HDR}</tr>
 		{PSEUDONYM_ROWS}
 	</table>
 

--- a/AU2/plugins/custom_plugins/html_templates/may_week_utils_players.html
+++ b/AU2/plugins/custom_plugins/html_templates/may_week_utils_players.html
@@ -22,7 +22,7 @@
 	<h3>Pseudonyms</h3> 
 	<table xmlns="" class="playerlist">
 		<!-- TODO: We should just have used jinja2 -->
-		<tr><th>Pseudonyms</th>{POINTS_HDR}<th>{MULTIPLIER_STR}</th>{TEAM_COLUMN_HDR}</tr>
+		<tr><th>Pseudonyms</th>{POINTS_HDR}{MULTIPLIER_COLUMN_HDR}{TEAM_COLUMN_HDR}</tr>
 		{PSEUDONYM_ROWS}
 	</table>
 

--- a/AU2/plugins/util/WantedManager.py
+++ b/AU2/plugins/util/WantedManager.py
@@ -54,6 +54,8 @@ class WantedManager:
         if last_event['event_time'] + last_event['wanted_duration'] > time:
             return True
 
+        return False
+
     def get_wanted_player_deaths(self, city_watch=False):
         wanted_deaths = []
         for player_id in self.wanted_events:

--- a/AU2/test/plugins/util/custom_plugins/test_MayWeekUtilitiesPlugin.py
+++ b/AU2/test/plugins/util/custom_plugins/test_MayWeekUtilitiesPlugin.py
@@ -289,3 +289,16 @@ class TestMayWeekUtilitiesPlugin:
         temp_scores3, perm_scores3 = plugin.calculate_scores()
         assert perm_scores3[p[0] + " identifier"] == -6
         assert temp_scores3[p[0] + " identifier"] == 0
+
+
+        # check that a floor is enforced if set
+        plugin.answer_config_perm_points({
+            plugin.html_ids["Investment %"]: invest_pct,
+            plugin.html_ids["Invest first?"]: True,
+            plugin.html_ids["Deplete Permanent Points?"]: True,
+            plugin.html_ids["Perm Points Floor"]: 0,
+            plugin.html_ids["Visible Points"]: [],
+        })
+        temp_scores4, perm_scores4 = plugin.calculate_scores()
+        assert perm_scores4[p[0] + " identifier"] == 0
+        assert temp_scores4[p[0] + " identifier"] == 0

--- a/AU2/test/plugins/util/custom_plugins/test_MayWeekUtilitiesPlugin.py
+++ b/AU2/test/plugins/util/custom_plugins/test_MayWeekUtilitiesPlugin.py
@@ -8,8 +8,9 @@ from AU2.test.test_utils import plugin_test, some_players, MockGame
 
 
 expected_scoring_params = [
-    "starting_score_casual", "starting_score_full", "death_penalty_pct", "death_penalty_fixed", "kill_bonus_pct",
-    "kill_bonus_fixed", "team_bonus_pct", "team_bonus_fixed", "multiplier_bonus_pct", "multiplier_bonus_fixed"
+    "starting_score_casual", "starting_score_full", "death_penalty_pct", "death_penalty_fixed", "wanted_penalty_pct",
+    "wanted_penalty_fixed", "kill_bonus_pct", "kill_bonus_fixed", "wanted_bonus_pct", "wanted_bonus_fixed",
+    "team_bonus_pct", "team_bonus_fixed", "multiplier_bonus_pct", "multiplier_bonus_fixed"
 ]
 
 
@@ -18,8 +19,8 @@ class TestMayWeekUtilitiesPlugin:
         """Helper function that sets random scoring parameters"""
         plugin = MayWeekUtilitiesPlugin()
         param_values = {
-            # values 0 to 100 are valid for all parameters
-            param.name: random.randint(0, 100) for param in plugin.scoring_parameters
+            # values 0 to 50  are valid for all parameters
+            param.name: random.randint(0, 50) for param in plugin.scoring_parameters
         }
 
         # 'magnify' starting scores to reduce likelihood of stupidly large fixed bonus/penalty values
@@ -295,3 +296,69 @@ class TestMayWeekUtilitiesPlugin:
         temp_scores4, perm_scores4 = plugin.calculate_scores()
         assert perm_scores4[p[0] + " identifier"] == 0
         assert temp_scores4[p[0] + " identifier"] == 0
+
+    @plugin_test
+    def test_wanted(self):
+        """Tests extra bonuses for killing wanted players and extra penalties for wanted players dying"""
+        plugin = MayWeekUtilitiesPlugin()
+
+        # make sure investment is disabled
+        plugin.answer_set_gimmicks({plugin.html_ids["Gimmicks"]: []})
+
+        param_values = self.set_random_scoring_parameters()
+
+        d = param_values["death_penalty_pct"] / 100
+        D = param_values["death_penalty_fixed"]
+        wd = param_values["wanted_penalty_pct"] / 100
+        Wd = param_values["wanted_penalty_fixed"]
+        b = param_values["kill_bonus_pct"] / 100
+        B = param_values["kill_bonus_fixed"]
+        wb = param_values["wanted_bonus_pct"] / 100
+        Wb = param_values["wanted_bonus_fixed"]
+        Sf = param_values["starting_score_full"]
+
+        p = some_players(50)
+        game = MockGame().having_assassins(p)
+
+        # have player 0 be killed while wanted by player 10
+        game.assassin(p[0]).is_involved_in_event(pluginState={
+            "WantedPlugin": {
+                p[0] + " identifier": (1, "test crime", "survive for 1 day")
+            }
+        }).then().new_datetime(100)
+        game.assassin(p[10]).kills(p[0])
+
+        # have player 1 be killed after having been automatically redeemed
+        game.assassin(p[1]).is_involved_in_event(pluginState={
+            "WantedPlugin": {
+                p[1] + " identifier": (1, "test crime", "survive for 1 day")
+            }
+        }).then().new_datetime(24*60)
+        game.assassin(p[11]).kills(p[1])
+
+        # have player 2 be killed after being *manually* redeemed
+        game.assassin(p[2]).is_involved_in_event(pluginState={
+            "WantedPlugin": {
+                p[2] + " identifier": (1, "test crime", "survive for 1 day")
+            }
+        }).then().new_datetime(10)
+        game.assassin(p[2]).is_involved_in_event(pluginState={
+            "WantedPlugin": {
+                p[2] + " identifier": (0, "", "")
+            }
+        }).then().assassin(p[12]).kills(p[2])
+
+        # now check scores calculated correctly
+        scores, _ = plugin.calculate_scores()
+
+        # player 0 is killed while wanted
+        assert isclose(scores[p[0] + " identifier"], max(0, Sf - d * Sf - D - wd * Sf - Wd))
+        # players 1 and 2 are killed while not wanted
+        for name in p[1:3]:
+            assert isclose(scores[name + " identifier"], max(0, Sf - d * Sf - D))
+
+        # player 10 killed a wanted player (with no other multipliers)
+        assert isclose(scores[p[10] + " identifier"], Sf + b * Sf + B + wb * Sf + Wb)
+        # players 11 and 12 killed non-wanted players (with no other multipliers)
+        for name in p[11:13]:
+            assert isclose(scores[name + " identifier"], Sf + b * Sf + B)

--- a/AU2/test/plugins/util/custom_plugins/test_MayWeekUtilitiesPlugin.py
+++ b/AU2/test/plugins/util/custom_plugins/test_MayWeekUtilitiesPlugin.py
@@ -22,6 +22,10 @@ class TestMayWeekUtilitiesPlugin:
             param.name: random.randint(0, 100) for param in plugin.scoring_parameters
         }
 
+        # 'magnify' starting scores to reduce likelihood of stupidly large fixed bonus/penalty values
+        param_values["starting_score_casual"] *= 10
+        param_values["starting_score_full"] *= 10
+
         # set scoring parameters
         plugin.answer_set_scoring_params({
             plugin.html_ids[name]: value for name, value in param_values.items()
@@ -72,6 +76,30 @@ class TestMayWeekUtilitiesPlugin:
         game.assassin(p[23]).kills(p[1], p[2])
         game.assassin(p[24]).kills(p[3], p[34])
 
+        # for testing that multipliers, teams ignored when these are disabled
+        e = game.assassin(p[25]).with_accomplices(p[40]).is_involved_in_event().model()
+        plugin.eps_set(e, "Multiplier Transfers", [(None, p[25] + " identifier")])
+        plugin.eps_set(e, "Team Changes", [(p[25] + " identifier", 1), (p[40] + " identifier", 1)])
+
+        plugin.eps_set(
+            game.assassin(p[25]).kills(p[35]).model(),
+            "Kills as Team",
+            [(p[25] + " identifier", p[35] + " identifier")]
+        )
+
+        # test BS points
+        bs_points = {
+            p[i] + " identifier": random.randint(1, 10) for i in (26, 36, 41)
+        }
+        plugin.eps_set(
+            game.assassin(p[26]).with_accomplices(p[36], p[41]).is_involved_in_event().model(),
+            "BS Points",
+            bs_points
+        )
+        game.new_datetime()
+        game.assassin(p[26]).kills(p[36])
+
+
         scores, perm_scores = plugin.calculate_scores()
 
         # since investment is disabled, permanent scores should all be 0
@@ -82,7 +110,7 @@ class TestMayWeekUtilitiesPlugin:
         for name in p[0:4]:
             assert scores[name + " identifier"] == max(0, Sc - D - d*Sc)
         # full player victims
-        for name in p[31:35]:
+        for name in p[31:36]:
             assert scores[name + " identifier"] == max(0, Sf - D - d*Sf)
         # full player killers
         # note: use isclose to test float values because we can get small rounding errors
@@ -91,3 +119,15 @@ class TestMayWeekUtilitiesPlugin:
         assert isclose(scores[p[22] + " identifier"], Sf + 2*(B + b * Sf))  # killed two full players
         assert isclose(scores[p[23] + " identifier"], Sf + 2*(B + b * Sc))  # killed two casual players
         assert isclose(scores[p[24] + " identifier"], Sf + B + b * Sf + B + b * Sc)  # killed one full one casual player
+        assert isclose(scores[p[25] + " identifier"], Sf + B + b * Sf)  # killed a full player (with ignored team kill + multiplier)
+
+        assert scores[p[40] + " identifier"] == Sf  # player on the same team as a team kill
+
+        # scores involving BS points
+        assert isclose(scores[p[26] + " identifier"], (
+                Sf + bs_points[p[26] + " identifier"] + B + b * (
+                    Sf + bs_points[p[36] + " identifier"]
+                )
+        ))  # has BS points + killed a player with BS points
+        assert isclose(scores[p[36] + " identifier"], max(0, (1 - d) * (Sf + bs_points[p[36] + " identifier"]) - D))  # victim with BS points
+        assert isclose(scores[p[41] + " identifier"], Sf + bs_points[p[41] + " identifier"])  # no kills

--- a/AU2/test/plugins/util/custom_plugins/test_MayWeekUtilitiesPlugin.py
+++ b/AU2/test/plugins/util/custom_plugins/test_MayWeekUtilitiesPlugin.py
@@ -133,9 +133,9 @@ class TestMayWeekUtilitiesPlugin:
         assert isclose(scores[p[41] + " identifier"], Sf + bs_points[p[41] + " identifier"])  # no kills
 
     @plugin_test
-    def test_investment_first(self):
+    def test_investment(self):
         """
-        Tests the permanent/temporary scores gimmick ONLY, with investment occurring first.
+        Tests the permanent/temporary scores gimmick ONLY
         """
         plugin = MayWeekUtilitiesPlugin()
         plugin.answer_set_gimmicks({plugin.html_ids["Gimmicks"]: ["investment"]})
@@ -148,7 +148,6 @@ class TestMayWeekUtilitiesPlugin:
         invest_pct = random.randint(1, 100)
         plugin.answer_config_perm_points({
             plugin.html_ids["Investment %"]: invest_pct,
-            plugin.html_ids["Invest first?"]: True,
             plugin.html_ids["Deplete Permanent Points?"]: True,
             plugin.html_ids["Perm Points Floor"]: None,
             plugin.html_ids["Visible Points"]: [],
@@ -252,7 +251,6 @@ class TestMayWeekUtilitiesPlugin:
         invest_pct = 50
         plugin.answer_config_perm_points({
             plugin.html_ids["Investment %"]: invest_pct,
-            plugin.html_ids["Invest first?"]: True,
             plugin.html_ids["Deplete Permanent Points?"]: True,
             plugin.html_ids["Perm Points Floor"]: None,
             plugin.html_ids["Visible Points"]: [],
@@ -294,7 +292,6 @@ class TestMayWeekUtilitiesPlugin:
         # check that a floor is enforced if set
         plugin.answer_config_perm_points({
             plugin.html_ids["Investment %"]: invest_pct,
-            plugin.html_ids["Invest first?"]: True,
             plugin.html_ids["Deplete Permanent Points?"]: True,
             plugin.html_ids["Perm Points Floor"]: 0,
             plugin.html_ids["Visible Points"]: [],

--- a/AU2/test/plugins/util/custom_plugins/test_MayWeekUtilitiesPlugin.py
+++ b/AU2/test/plugins/util/custom_plugins/test_MayWeekUtilitiesPlugin.py
@@ -106,14 +106,14 @@ class TestMayWeekUtilitiesPlugin:
         for name in p:
             assert perm_scores[name + " identifier"] == 0
 
+        # note: use isclose to test float values because we can get small rounding errors
         # casual victims
         for name in p[0:4]:
-            assert scores[name + " identifier"] == max(0, Sc - D - d*Sc)
+            assert isclose(scores[name + " identifier"], max(0, Sc - D - d*Sc))
         # full player victims
         for name in p[31:36]:
-            assert scores[name + " identifier"] == max(0, Sf - D - d*Sf)
+            assert isclose(scores[name + " identifier"], max(0, Sf - D - d*Sf))
         # full player killers
-        # note: use isclose to test float values because we can get small rounding errors
         assert isclose(scores[p[20] + " identifier"], Sf + B + b * Sf)  # killed a full player
         assert isclose(scores[p[21] + " identifier"], Sf + B + b * Sc)  # killed a casual player
         assert isclose(scores[p[22] + " identifier"], Sf + 2*(B + b * Sf))  # killed two full players

--- a/AU2/test/plugins/util/custom_plugins/test_MayWeekUtilitiesPlugin.py
+++ b/AU2/test/plugins/util/custom_plugins/test_MayWeekUtilitiesPlugin.py
@@ -18,8 +18,8 @@ class TestMayWeekUtilitiesPlugin:
         """Helper function that sets random scoring parameters"""
         plugin = MayWeekUtilitiesPlugin()
         param_values = {
-            # values 1 to 100 are valid for all the scoring parameters
-            param.name: random.randint(1, 100) for param in plugin.scoring_parameters
+            # values 0 to 100 are valid for all parameters
+            param.name: random.randint(0, 100) for param in plugin.scoring_parameters
         }
 
         # 'magnify' starting scores to reduce likelihood of stupidly large fixed bonus/penalty values
@@ -101,10 +101,6 @@ class TestMayWeekUtilitiesPlugin:
 
 
         scores, perm_scores = plugin.calculate_scores()
-
-        # since investment is disabled, permanent scores should all be 0
-        for name in p:
-            assert perm_scores[name + " identifier"] == 0
 
         # note: use isclose to test float values because we can get small rounding errors
         # casual victims

--- a/AU2/test/plugins/util/custom_plugins/test_MayWeekUtilitiesPlugin.py
+++ b/AU2/test/plugins/util/custom_plugins/test_MayWeekUtilitiesPlugin.py
@@ -10,7 +10,8 @@ from AU2.test.test_utils import plugin_test, some_players, MockGame
 expected_scoring_params = [
     "starting_score_casual", "starting_score_full", "death_penalty_pct", "death_penalty_fixed", "wanted_penalty_pct",
     "wanted_penalty_fixed", "kill_bonus_pct", "kill_bonus_fixed", "wanted_bonus_pct", "wanted_bonus_fixed",
-    "team_bonus_pct", "team_bonus_fixed", "multiplier_bonus_pct", "multiplier_bonus_fixed"
+    "team_bonus_pct", "team_bonus_fixed", "multiplier_bonus_pct", "multiplier_bonus_fixed", "multiple_kill_penalty_pct",
+    "multiple_death_mitigation_pct"
 ]
 
 
@@ -141,6 +142,7 @@ class TestMayWeekUtilitiesPlugin:
         b = param_values["kill_bonus_pct"] / 100
         B = param_values["kill_bonus_fixed"]
         Sf = param_values["starting_score_full"]
+        pk = param_values["multiple_kill_penalty_pct"] / 100
 
         invest_pct = random.randint(1, 100)
         plugin.answer_config_perm_points({
@@ -204,7 +206,7 @@ class TestMayWeekUtilitiesPlugin:
         assert isclose(temp_scores2[p[0] + " identifier"],
                        temp_scores[p[0] + " identifier"] + B + b * Sf)
         assert isclose(temp_scores2[p[1] + " identifier"],
-                       temp_scores[p[1] + " identifier"] + B + b * temp_scores[p[11] + " identifier"])
+                       temp_scores[p[1] + " identifier"] + (B + b * temp_scores[p[11] + " identifier"]) * pk)
 
         # now move to the next day (but less than 24 hrs from the original kills!)
         game.new_datetime(minutes=16*60)
@@ -223,7 +225,7 @@ class TestMayWeekUtilitiesPlugin:
 
         # also check that temp scores updated correctly
         assert isclose(temp_scores3[p[0] + " identifier"],
-                       temp_scores2[p[0] + " identifier"] + B + b * temp_scores2[p[12] + " identifier"])
+                       temp_scores2[p[0] + " identifier"] + (B + b * temp_scores2[p[12] + " identifier"]) * pk)
         assert isclose(temp_scores3[p[1] + " identifier"],
                        keep_prop * temp_scores2[p[1] + " identifier"] + B + b * temp_scores2[p[10] + " identifier"])
         assert isclose(temp_scores3[p[2] + " identifier"],
@@ -362,3 +364,80 @@ class TestMayWeekUtilitiesPlugin:
         # players 11 and 12 killed non-wanted players (with no other multipliers)
         for name in p[11:13]:
             assert isclose(scores[name + " identifier"], Sf + b * Sf + B)
+
+    @plugin_test
+    def test_tapering_points(self):
+        """
+        Tests the multipliers applied to points gained / lost from repeated kills
+        """
+        plugin = MayWeekUtilitiesPlugin()
+
+        # make sure investment is disabled, as this complicates the expected scores...
+        plugin.answer_set_gimmicks({plugin.html_ids["Gimmicks"]: []})
+
+        param_values = self.set_random_scoring_parameters()
+
+        d = param_values["death_penalty_pct"] / 100
+        D = param_values["death_penalty_fixed"]
+        wd = param_values["wanted_penalty_pct"] / 100
+        Wd = param_values["wanted_penalty_fixed"]
+        b = param_values["kill_bonus_pct"] / 100
+        B = param_values["kill_bonus_fixed"]
+        wb = param_values["wanted_bonus_pct"] / 100
+        Wb = param_values["wanted_bonus_fixed"]
+        Sf = param_values["starting_score_full"]
+
+        pk = param_values["multiple_kill_penalty_pct"] / 100
+        pv = param_values["multiple_death_mitigation_pct"] / 100
+
+        p = some_players(60)
+        game = MockGame().having_assassins(p)
+
+        # setup some initial kills
+        for i in range(10):
+            game.assassin(p[i]).kills(p[i+20])
+
+        # have player 20 be killed a second time by player while wanted to test that this bonus is applied first
+        game.assassin(p[20]).is_involved_in_event(pluginState={
+            "WantedPlugin": {
+                p[20] + " identifier": (1, "test crime", "survive for 1 day")
+            }
+        }).then().new_datetime(100)
+        game.assassin(p[0]).kills(p[20])
+        # have player 21 be killed a second time, but by a different player who hasn't made a kill
+        game.assassin(p[10]).kills(p[21])
+        # have player 22 be killed a second time, by a different player making their second kill
+        game.assassin(p[1]).kills(p[22])
+        # have player 2 kill a player who hasn't been killed previously
+        game.assassin(p[2]).kills(p[30])
+
+        # for testing additional tapering
+        n_repeats = {(p[i], p[i+10]): random.randint(2, 10) for i in range(40, 50)}
+        for (killer, victim), n in n_repeats.items():
+            for _ in range(n):
+                game.assassin(killer).kills(victim)
+
+        scores, _ = plugin.calculate_scores()
+
+        ONE_KILL_SCORE = Sf + B + b*Sf
+        ONE_DEATH_SCORE = max(0, Sf - D - d*Sf)
+
+        assert isclose(scores[p[0] + " identifier"],
+                       ONE_KILL_SCORE + (B + b * ONE_DEATH_SCORE + Wb + wb * ONE_DEATH_SCORE) * pk)
+        assert isclose(scores[p[20] + " identifier"],
+                       max(0, ONE_DEATH_SCORE - (D + d * ONE_DEATH_SCORE + Wd + wd * ONE_DEATH_SCORE) * pv))
+        assert isclose(scores[p[10] + " identifier"], Sf + B + b * ONE_DEATH_SCORE)
+        assert isclose(scores[p[21] + " identifier"], max(0, ONE_DEATH_SCORE - D - d * ONE_DEATH_SCORE))
+        assert isclose(scores[p[1] + " identifier"], ONE_KILL_SCORE + B + b * ONE_DEATH_SCORE)
+        assert isclose(scores[p[22] + " identifier"], max(0, ONE_DEATH_SCORE - D - d * ONE_DEATH_SCORE))
+        assert isclose(scores[p[2] + " identifier"], ONE_KILL_SCORE + B + b * Sf)
+
+        for (killer, victim), n in n_repeats.items():
+            expected_victim_score = Sf
+            expected_killer_score = Sf
+            for i in range(n):
+                expected_killer_score += (B + b * expected_victim_score) * (pk ** i)
+                expected_victim_score -= (D + d * expected_victim_score) * (pv ** i)
+                expected_victim_score = max(0, expected_victim_score)
+            assert isclose(scores[killer + " identifier"], expected_killer_score)
+            assert isclose(scores[victim + " identifier"], expected_victim_score)

--- a/AU2/test/plugins/util/custom_plugins/test_MayWeekUtilitiesPlugin.py
+++ b/AU2/test/plugins/util/custom_plugins/test_MayWeekUtilitiesPlugin.py
@@ -1,0 +1,93 @@
+import random
+
+from math import isclose
+from typing import Dict
+
+from AU2.plugins.custom_plugins.MayWeekUtilitiesPlugin import MayWeekUtilitiesPlugin
+from AU2.test.test_utils import plugin_test, some_players, MockGame
+
+
+expected_scoring_params = [
+    "starting_score_casual", "starting_score_full", "death_penalty_pct", "death_penalty_fixed", "kill_bonus_pct",
+    "kill_bonus_fixed", "team_bonus_pct", "team_bonus_fixed", "multiplier_bonus_pct", "multiplier_bonus_fixed"
+]
+
+
+class TestMayWeekUtilitiesPlugin:
+    def set_random_scoring_parameters(self) -> Dict[str, int]:
+        """Helper function that sets random scoring parameters"""
+        plugin = MayWeekUtilitiesPlugin()
+        param_values = {
+            # values 0 to 100 are valid for all the scoring parameters
+            param.name: random.randint(0, 100) for param in plugin.scoring_parameters
+        }
+
+        # set scoring parameters
+        plugin.answer_set_scoring_params({
+            plugin.html_ids[name]: value for name, value in param_values.items()
+        })
+
+        return param_values
+
+    @plugin_test
+    def test_set_scoring_params(self):
+        plugin = MayWeekUtilitiesPlugin()
+
+        param_values = self.set_random_scoring_parameters()
+
+        # verify that params are set correctly
+        for param_name in expected_scoring_params:
+            assert plugin.gsdb_get(param_name) == param_values[param_name]
+
+    @plugin_test
+    def test_calculate_scores_no_gimmicks(self):
+        """Tests that scores are calculated correctly when all gimmicks are disabled"""
+        plugin = MayWeekUtilitiesPlugin()
+        plugin.answer_set_gimmicks({plugin.html_ids["Gimmicks"]: []})
+        param_values = self.set_random_scoring_parameters()
+
+        d = param_values["death_penalty_pct"] / 100
+        D = param_values["death_penalty_fixed"]
+        b = param_values["kill_bonus_pct"] / 100
+        B = param_values["kill_bonus_fixed"]
+        Sc = param_values["starting_score_casual"]
+        Sf = param_values["starting_score_full"]
+
+        p = some_players(50)
+        game = MockGame().having_assassins(p)
+
+        game.assassin(p[0]).with_accomplices(*p[:20]).are_city_watch()
+
+        # check that initial scores are correct
+        scores, _ = plugin.calculate_scores()
+        for name in p[:20]:
+            assert scores[name + " identifier"] == Sc
+        for name in p[20:]:
+            assert scores[name + " identifier"] == Sf
+
+        # test kills
+        game.assassin(p[20]).kills(p[31])
+        game.assassin(p[21]).kills(p[0])
+        game.assassin(p[22]).kills(p[32], p[33])
+        game.assassin(p[23]).kills(p[1], p[2])
+        game.assassin(p[24]).kills(p[3], p[34])
+
+        scores, perm_scores = plugin.calculate_scores()
+
+        # since investment is disabled, permanent scores should all be 0
+        for name in p:
+            assert perm_scores[name + " identifier"] == 0
+
+        # casual victims
+        for name in p[0:4]:
+            assert scores[name + " identifier"] == max(0, Sc - D - d*Sc)
+        # full player victims
+        for name in p[31:35]:
+            assert scores[name + " identifier"] == max(0, Sf - D - d*Sf)
+        # full player killers
+        # note: use isclose to test float values because we can get small rounding errors
+        assert isclose(scores[p[20] + " identifier"], Sf + B + b * Sf)  # killed a full player
+        assert isclose(scores[p[21] + " identifier"], Sf + B + b * Sc)  # killed a casual player
+        assert isclose(scores[p[22] + " identifier"], Sf + 2*(B + b * Sf))  # killed two full players
+        assert isclose(scores[p[23] + " identifier"], Sf + 2*(B + b * Sc))  # killed two casual players
+        assert isclose(scores[p[24] + " identifier"], Sf + B + b * Sf + B + b * Sc)  # killed one full one casual player

--- a/AU2/test/plugins/util/custom_plugins/test_MayWeekUtilitiesPlugin.py
+++ b/AU2/test/plugins/util/custom_plugins/test_MayWeekUtilitiesPlugin.py
@@ -141,11 +141,8 @@ class TestMayWeekUtilitiesPlugin:
         plugin.answer_set_gimmicks({plugin.html_ids["Gimmicks"]: ["investment"]})
         param_values = self.set_random_scoring_parameters()
 
-        d = param_values["death_penalty_pct"] / 100
-        D = param_values["death_penalty_fixed"]
         b = param_values["kill_bonus_pct"] / 100
         B = param_values["kill_bonus_fixed"]
-        Sc = param_values["starting_score_casual"]
         Sf = param_values["starting_score_full"]
 
         invest_pct = random.randint(1, 100)
@@ -237,3 +234,58 @@ class TestMayWeekUtilitiesPlugin:
                        keep_prop * temp_scores2[p[2] + " identifier"]
                        + B + b * temp_scores2[p[11] + " identifier"]
                        + B + b * temp_scores2[p[13] + " identifier"])
+
+    @plugin_test
+    def test_betting_gold(self):
+        """Unit test to check that permenant points can be depleted using -ve BS points"""
+        plugin = MayWeekUtilitiesPlugin()
+        plugin.answer_set_gimmicks({plugin.html_ids["Gimmicks"]: ["investment"]})
+        param_values = self.set_random_scoring_parameters()
+
+        # set these params deterministically to guarantee that we deplete permanent points
+        param_values["kill_bonus_pct"] = 0
+        param_values["kill_bonus_fixed"] = 0
+        param_values["starting_score_full"] = 10
+        plugin.answer_set_scoring_params({
+            plugin.html_ids[name]: value for name, value in param_values.items()
+        })
+        invest_pct = 50
+        plugin.answer_config_perm_points({
+            plugin.html_ids["Investment %"]: invest_pct,
+            plugin.html_ids["Invest first?"]: True,
+            plugin.html_ids["Deplete Permanent Points?"]: True,
+            plugin.html_ids["Perm Points Floor"]: None,
+            plugin.html_ids["Visible Points"]: [],
+        })
+        invest_prop = invest_pct / 100
+
+        p = some_players(2)
+        game = MockGame().having_assassins(p)
+
+        # a kill to get some points invested
+        game.assassin(p[0]).kills(p[1])
+        temp_scores, perm_scores = plugin.calculate_scores()
+        assert perm_scores[p[0] + " identifier"] == 5
+        assert temp_scores[p[0] + " identifier"] == 5  # kill bonuses are set to 0 for this unit test
+
+        # negative BS points to deplete permanent points
+        game.new_datetime()
+        plugin.eps_set(
+            game.assassin(p[0]).is_involved_in_event().model(),
+            "BS Points",
+            {p[0] + " identifier": -8}
+        )
+        temp_scores2, perm_scores2 = plugin.calculate_scores()
+        assert perm_scores2[p[0] + " identifier"] == 2
+        assert temp_scores2[p[0] + " identifier"] == 0
+
+        # check that perm points can go negative when no floor is set
+        game.new_datetime()
+        plugin.eps_set(
+            game.assassin(p[0]).is_involved_in_event().model(),
+            "BS Points",
+            {p[0] + " identifier": -8}
+        )
+        temp_scores3, perm_scores3 = plugin.calculate_scores()
+        assert perm_scores3[p[0] + " identifier"] == -6
+        assert temp_scores3[p[0] + " identifier"] == 0

--- a/AU2/test/plugins/util/custom_plugins/test_MayWeekUtilitiesPlugin.py
+++ b/AU2/test/plugins/util/custom_plugins/test_MayWeekUtilitiesPlugin.py
@@ -18,8 +18,8 @@ class TestMayWeekUtilitiesPlugin:
         """Helper function that sets random scoring parameters"""
         plugin = MayWeekUtilitiesPlugin()
         param_values = {
-            # values 0 to 100 are valid for all the scoring parameters
-            param.name: random.randint(0, 100) for param in plugin.scoring_parameters
+            # values 1 to 100 are valid for all the scoring parameters
+            param.name: random.randint(1, 100) for param in plugin.scoring_parameters
         }
 
         # 'magnify' starting scores to reduce likelihood of stupidly large fixed bonus/penalty values
@@ -131,3 +131,109 @@ class TestMayWeekUtilitiesPlugin:
         ))  # has BS points + killed a player with BS points
         assert isclose(scores[p[36] + " identifier"], max(0, (1 - d) * (Sf + bs_points[p[36] + " identifier"]) - D))  # victim with BS points
         assert isclose(scores[p[41] + " identifier"], Sf + bs_points[p[41] + " identifier"])  # no kills
+
+    @plugin_test
+    def test_investment_first(self):
+        """
+        Tests the permanent/temporary scores gimmick ONLY, with investment occurring first.
+        """
+        plugin = MayWeekUtilitiesPlugin()
+        plugin.answer_set_gimmicks({plugin.html_ids["Gimmicks"]: ["investment"]})
+        param_values = self.set_random_scoring_parameters()
+
+        d = param_values["death_penalty_pct"] / 100
+        D = param_values["death_penalty_fixed"]
+        b = param_values["kill_bonus_pct"] / 100
+        B = param_values["kill_bonus_fixed"]
+        Sc = param_values["starting_score_casual"]
+        Sf = param_values["starting_score_full"]
+
+        invest_pct = random.randint(1, 100)
+        plugin.answer_config_perm_points({
+            plugin.html_ids["Investment %"]: invest_pct,
+            plugin.html_ids["Invest first?"]: True,
+            plugin.html_ids["Deplete Permanent Points?"]: True,
+            plugin.html_ids["Perm Points Floor"]: None,
+            plugin.html_ids["Visible Points"]: [],
+        })
+        invest_prop = invest_pct / 100
+        keep_prop = 1 - invest_prop  # proportion of temporary points NOT invested
+
+        p = some_players(50)
+        game = MockGame().having_assassins(p)
+        # ensure that the starting hour is 1pm so that we can test the 'same day' condition properly
+        game.date = game.date.replace(hour=13)
+
+        # give a player 0 BS points
+        bs_points = random.randint(1, 10)
+        plugin.eps_set(
+            game.assassin(p[0]).is_involved_in_event().model(),
+            "BS Points",
+            {p[0] + " identifier": bs_points}
+        )
+        game.new_datetime()
+
+        # some kills
+        game.assassin(p[0]).kills(p[10])
+        plugin.eps_set(
+            game.assassin(p[1]).kills(p[11]).model(),
+            "BS Points",
+            {p[1] + " identifier": bs_points}
+        )
+
+        temp_scores, perm_scores = plugin.calculate_scores()
+        # player 0's first kill of the day occurs after getting BS points, so invests some of it
+        assert isclose(perm_scores[p[0] + " identifier"], invest_prop * (Sf + bs_points))
+        assert isclose(temp_scores[p[0] + " identifier"], keep_prop * (Sf + bs_points) + B + b * Sf)
+        # on the other hand, player 1 gains the BS points during the kill so they aren't invested
+        assert isclose(perm_scores[p[1] + " identifier"], invest_prop * Sf)
+        assert isclose(temp_scores[p[1] + " identifier"], keep_prop * Sf + B + b * Sf + bs_points)
+
+        # no other players should have any permanent points at this stage either
+        for name in p[2:]:
+            assert perm_scores[name + " identifier"] == 0
+
+        # now, move later in same day and add more kills for the same players. They shouldn't invest any more!
+        game.new_datetime(minutes=4*60)
+        game.assassin(p[0]).kills(p[12])  # new kill
+        game.assassin(p[1]).kills(p[11])  # old kill
+        game.assassin(p[2]).kills(p[10])  # new kill for player 2 but old victim
+
+        temp_scores2, perm_scores2 = plugin.calculate_scores()
+
+        # permanent scores for players 0, 1 shouldn't change
+        for name in p[:2]:
+            assert perm_scores2[name + " identifier"] == perm_scores[name + " identifier"]
+        # but player 2 should invest here
+        assert isclose(perm_scores2[p[2] + " identifier"], invest_prop * Sf)
+        assert isclose(temp_scores2[p[2] + " identifier"], keep_prop * Sf + B + b * temp_scores[p[10] + " identifier"])
+        # and all the killer's temp scores should change
+        assert isclose(temp_scores2[p[0] + " identifier"],
+                       temp_scores[p[0] + " identifier"] + B + b * Sf)
+        assert isclose(temp_scores2[p[1] + " identifier"],
+                       temp_scores[p[1] + " identifier"] + B + b * temp_scores[p[11] + " identifier"])
+
+        # now move to the next day (but less than 24 hrs from the original kills!)
+        game.new_datetime(minutes=16*60)
+        game.assassin(p[0]).kills(p[12])  # old kill
+        game.assassin(p[1]).kills(p[10])  # new kill
+        game.assassin(p[2]).kills(p[11], p[13])  # two new kills: only triggers one investment...
+
+        temp_scores3, perm_scores3 = plugin.calculate_scores()
+        # player 0 shouldn't have invested anything, since they killed someone they already had
+        assert perm_scores3[p[0] + " identifier"] == perm_scores2[p[0] + " identifier"]
+        # but both players 1 and 2 should have invested again
+        assert isclose(perm_scores3[p[1] + " identifier"],
+                       perm_scores2[p[1] + " identifier"] + invest_prop * temp_scores2[p[1] + " identifier"])
+        assert isclose(perm_scores3[p[2] + " identifier"],
+                       perm_scores2[p[2] + " identifier"] + invest_prop * temp_scores2[p[2] + " identifier"])
+
+        # also check that temp scores updated correctly
+        assert isclose(temp_scores3[p[0] + " identifier"],
+                       temp_scores2[p[0] + " identifier"] + B + b * temp_scores2[p[12] + " identifier"])
+        assert isclose(temp_scores3[p[1] + " identifier"],
+                       keep_prop * temp_scores2[p[1] + " identifier"] + B + b * temp_scores2[p[10] + " identifier"])
+        assert isclose(temp_scores3[p[2] + " identifier"],
+                       keep_prop * temp_scores2[p[2] + " identifier"]
+                       + B + b * temp_scores2[p[11] + " identifier"]
+                       + B + b * temp_scores2[p[13] + " identifier"])

--- a/AU2/test/plugins/util/custom_plugins/test_ScoringPlugin.py
+++ b/AU2/test/plugins/util/custom_plugins/test_ScoringPlugin.py
@@ -15,7 +15,7 @@ class TestScoringPlugin:
         m = ScoreManager(assassin_ids=[name + " identifier" for name in mockGame.all_assassins
                                        if not (filter_city_watch and mockGame.assassin_model(name).is_city_watch)],
                          perma_death=perma_death)
-        for e in sorted(EVENTS_DATABASE.events.values(), key=lambda e: e.datetime):
+        for e in EVENTS_DATABASE.events_chronologically():
             m.add_event(e)
         return m
 


### PR DESCRIPTION
This PR extends `MayWeekUtilitiesPlugin` to implement the 'investment' mechanism for MW 2026. Specifically, `calculate_scores` now returns two sets of scores: 'temporary' and 'permanent' points.

If the investment mechanic is enabled, for each player the first time each day that they kill someone they haven't previously, a specified portion of their temporary points are transferred into permanent points. (This happens before they gain any points from the kill. Originally I had implemented a config option for whether it should happen before or after, but I removed this because the 'after' setting would not play nicely with events that have multiple kills).

The investment mechanic comes with a few config options:
- What % of temporary points should be invested
- Whether to deplete permanent points when temporary points go negative. This behaviour allows the betting mechanics for MW2026 to work correctly by allowing players to lose gold if they wagered more than they have in temporary points, but isn't necessarily always desirable, hence why it is configurable.
- A 'points floor' for permanent points, for when the above is enabled
- Which of temporary points, permanent points, total points to show on the player list. This is a config option because of the precedent of MW2024 not listing giving that game's version of temporary points separately. This config option only has any effect if investment is enabled.

There are also cosmetics settings for naming the different types of points.

(UPDATE:​) Anastasia also wanted there to be bonus points for killing Wanted players. To implement this I have simplified the scoring formula so that multiplicative bonuses no longer 'stack' onto other bonuses, but rather only award a set portion of the victim's pre-death score.
I think that, if in a future game an umpire does want the points system of MW2025, it would be clearer to implement this using an additional pair of parameters for bonuses when a kill is made both as a team AND with a multiplier.

(SECOND UPDATE:​) There is now also a parameter for a multiplicative penalty applied to the points awared when a player kills someone they have before. To allow parameters to be set such that points are 'stolen' there is also a parameter that can reduce the points lost by victims. Both of these parameters are applied *on top* of bonuses / penalties, which somewhat works against the simplification of the scoring mentioned above[^1].... In the case that the victim has already been killed multiple times by the killer, the penalty is applied multiple times, so that such kills have diminishing returns.

[^1]: As a side note: perhaps we ought to make the may week scoring formulae more flexible, like Open Season scoring is. Time to take another look at #31, perhaps?

This PR furthermore makes various other changes:
- The `Enable/disable Teams` config option is replaced with a generalised config option allowing the user to select what combination of the three May Week features (Teams, Multipliers, Investment) should be enabled. This allows Multipliers to be disabled, which was not previously an option.
- A May Week option is added to `Setup Game`. It is currently a little janky because it gives config options for all the MW features regardless of which are enabled, but with an explanation for this to the user. Also, the requirement to have players added first is dropped for the May Week option as this is only needed for `TargetingPlugin` (because of seeding) and `CityWatchPlugin` (because of selecting the Umpires / Commander of the City Watch).
- Events are now processed chronologically rather than in order of datetime. In order to make this possible the UI of `AssassinDependentTransferEntry` is 'downgraded' to not require knowlege of current multiplier owners. Specifically, rather than listing all possible multiplier transfers, it now simply asks for a selection of players to gain multipliers and a selection to use them. This is a stopgap until we can figure something out to allow the original interface to work with chronological processing of events... 
- (UPDATE:​) BS points are input using an `AssassinDependentFloatEntry` rather than `AssassinDependentIntegerEntry`

**Testing:** The PR also includes some unit tests. I only added tests so far for those features that will actually be used in MW2026 (so not for teams / multipliers, other than that they are ignored if disabled)